### PR TITLE
Make finding the corresponding BasicBlock more robust.

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -154,6 +154,10 @@ const char PPTimerDescription[] = "Pseudo Probe Emission";
 const char PPGroupName[] = "pseudo probe";
 const char PPGroupDescription[] = "Pseudo Probe Emission";
 
+// A basic block index value used in the bb_addr_map to indicate that there
+// is no correspoinding IR block for the given machine basic block.
+const uint64_t NO_BB = UINT64_MAX;
+
 STATISTIC(EmittedInsts, "Number of machine instrs printed");
 
 char AsmPrinter::ID = 0;
@@ -1105,15 +1109,26 @@ void AsmPrinter::emitBBAddrMapSection(const MachineFunction &MF) {
     emitLabelDifferenceAsULEB128(MBB.getEndSymbol(), MBBSymbol);
     OutStreamer->emitULEB128IntValue(getBBAddrMapMetadata(MBB));
     // Emit the index of the corresponding LLVMIR basic block.
-    size_t i = 0;
-    for (auto It = F.begin(); It != F.end(); It++) {
-      const BasicBlock *BB = &*It;
-      if (BB == MBB.getBasicBlock()) {
-          break;
+    size_t BBIdx = 0;
+    bool found = false;
+    const BasicBlock *FindBB = MBB.getBasicBlock();
+    if (FindBB == nullptr) {
+      found = true;
+      BBIdx = NO_BB;
+    } else {
+      for (auto It = F.begin(); It != F.end(); It++) {
+        const BasicBlock *BB = &*It;
+        if (BB == FindBB) {
+            found = true;
+            break;
+        }
+        BBIdx++;
+        assert(BBIdx != NO_BB); // Or we are out of encoding space.
       }
-      i++;
     }
-    OutStreamer->emitULEB128IntValue(i);
+    if (!found)
+      OutContext.reportError(SMLoc(), "Couldn't find the block's index");
+    OutStreamer->emitULEB128IntValue(BBIdx);
   }
   OutStreamer->PopSection();
 }


### PR DESCRIPTION
In a previous PR we modified the `.llvm_bb_addr_map` section, adding the
orignial basic block index. This commit improves that code in two ways:

1) Catch the case where MachineBasicBlock::getBasicBlock() returns a
null pointer. To quote the documentation:

> Note that this may be NULL if this instance does not correspond
> directly to an LLVM basic block.

We use the block index u64::MAX to encode this condition (note that
although the field in the section is uleb128, LLVM only allows block
indices that fit in a u64).

An upcoming change to yk will check for this condition at runtime.

2) Currently if a block isn't found, then the resulting block index is
incorrect: The last index used in the loop is erroneously used.This
commit causes an error at compile time instead.