### PR TITLE
Add flag to embed final bitcode.

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -36,6 +36,7 @@
 #include "llvm/BinaryFormat/COFF.h"
 #include "llvm/BinaryFormat/Dwarf.h"
 #include "llvm/BinaryFormat/ELF.h"
+#include "llvm/Bitcode/BitcodeWriter.h"
 #include "llvm/CodeGen/GCMetadata.h"
 #include "llvm/CodeGen/GCMetadataPrinter.h"
 #include "llvm/CodeGen/GCStrategy.h"
@@ -138,6 +139,10 @@ using namespace llvm;
 static cl::opt<bool>
     DisableDebugInfoPrinting("disable-debug-info-print", cl::Hidden,
                              cl::desc("Disable debug info printing"));
+
+static cl::opt<bool>
+    EmbedBitcodeFinal("embed-bitcode-final", cl::NotHidden,
+                             cl::desc("Embed final IR as bitcode after all optimisations and transformations have run."));
 
 const char DWARFGroupName[] = "dwarf";
 const char DWARFGroupDescription[] = "DWARF Emission";
@@ -1680,6 +1685,18 @@ void AsmPrinter::emitRemarksSection(remarks::RemarkStreamer &RS) {
 }
 
 bool AsmPrinter::doFinalization(Module &M) {
+  // The `embed-bitcode` flag serialises the IR after only architecture
+  // agnostic optimisations have been run, but then proceeds to apply other
+  // optimisations and transformations afterwards. Sometimes this final version
+  // is precisely what we are interested in. The `embed-bitcode-final` flag
+  // waits until all optimisations/transformations have been run before
+  // embedding the IR.
+  if (EmbedBitcodeFinal)
+    llvm::EmbedBitcodeInModule(M, llvm::MemoryBufferRef(),
+                               /*EmbedBitcode*/ true,
+                               /*EmbedCmdline*/ false,
+                               /*CmdArgs*/ std::vector<uint8_t>());
+
   // Set the MachineFunction to nullptr so that we can catch attempted
   // accesses to MF specific features at the module level and so that
   // we can conditionalize accesses based on whether or not it is nullptr.


### PR DESCRIPTION
The `embed-bitcode` flag serialises the IR after only architecture
agnostic optimisations have been run, but then proceeds to apply other
optimisations afterwards. Sometimes, this final version is precisely
what we are interested in. The `embed-bitcode-final` flag waits until
all optimisations have been run before embedding the IR.