### PR TITLE
Add optnoneall attribute.

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -2121,6 +2121,12 @@ def OptimizeNone : InheritableAttr {
   let Documentation = [OptnoneDocs];
 }
 
+def OptimizeNoneAll : InheritableAttr {
+  let Spellings = [Clang<"optnoneall">];
+  let Subjects = SubjectList<[Function, ObjCMethod]>;
+  let Documentation = [OptnoneallDocs];
+}
+
 def Overloadable : Attr {
   let Spellings = [Clang<"overloadable">];
   let Subjects = SubjectList<[Function], ErrorDiag>;

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -3098,6 +3098,14 @@ attributes.
   }];
 }
 
+def OptnoneallDocs : Documentation {
+  let Category = DocCatFunction;
+  let Content = [{
+The ``optnoneall`` attribute is similar to ``optnone``, but it also disables
+inter-procedural (IPO) optimisation passes.
+  }];
+}
+
 def LoopHintDocs : Documentation {
   let Category = DocCatStmt;
   let Heading = "#pragma clang loop";

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -3300,6 +3300,8 @@ public:
                                     StringRef Name);
   OptimizeNoneAttr *mergeOptimizeNoneAttr(Decl *D,
                                           const AttributeCommonInfo &CI);
+  OptimizeNoneAllAttr *mergeOptimizeNoneAllAttr(Decl *D,
+                                          const AttributeCommonInfo &CI);
   InternalLinkageAttr *mergeInternalLinkageAttr(Decl *D, const ParsedAttr &AL);
   InternalLinkageAttr *mergeInternalLinkageAttr(Decl *D,
                                                 const InternalLinkageAttr &AL);

--- a/llvm/include/llvm/Bitcode/LLVMBitCodes.h
+++ b/llvm/include/llvm/Bitcode/LLVMBitCodes.h
@@ -657,6 +657,7 @@ enum AttributeKindCodes {
   ATTR_KIND_NO_CALLBACK = 71,
   ATTR_KIND_HOT = 72,
   ATTR_KIND_NO_PROFILE = 73,
+  ATTR_KIND_OPTIMIZE_NONE_ALL = 74,
 };
 
 enum ComdatSelectionKindCodes {

--- a/llvm/include/llvm/IR/Attributes.td
+++ b/llvm/include/llvm/IR/Attributes.td
@@ -166,6 +166,9 @@ def OptimizeForSize : EnumAttr<"optsize">;
 /// Function must not be optimized.
 def OptimizeNone : EnumAttr<"optnone">;
 
+/// Function must not be optimized, including inter-procedurally.
+def OptimizeNoneAll : EnumAttr<"optnoneall">;
+
 /// Similar to byval but without a copy.
 def Preallocated : TypeAttr<"preallocated">;
 

--- a/llvm/include/llvm/IR/Function.h
+++ b/llvm/include/llvm/IR/Function.h
@@ -676,7 +676,12 @@ public:
   }
 
   /// Do not optimize this function (-O0).
-  bool hasOptNone() const { return hasFnAttribute(Attribute::OptimizeNone); }
+  bool hasOptNone() const {
+    return hasFnAttribute(Attribute::OptimizeNone) || hasFnAttribute(Attribute::OptimizeNoneAll);
+  }
+
+  /// Do not optimize this function. Not even inter-procedurally.
+  bool hasOptNoneAll() const { return hasFnAttribute(Attribute::OptimizeNoneAll); }
 
   /// Optimize this function for minimum size (-Oz).
   bool hasMinSize() const { return hasFnAttribute(Attribute::MinSize); }

--- a/llvm/lib/AsmParser/LLLexer.cpp
+++ b/llvm/lib/AsmParser/LLLexer.cpp
@@ -673,6 +673,7 @@ lltok::Kind LLLexer::LexIdentifier() {
   KEYWORD(null_pointer_is_valid);
   KEYWORD(optforfuzzing);
   KEYWORD(optnone);
+  KEYWORD(optnoneall);
   KEYWORD(optsize);
   KEYWORD(preallocated);
   KEYWORD(readnone);

--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -1376,6 +1376,7 @@ bool LLParser::parseFnAttributeValuePairs(AttrBuilder &B,
     case lltok::kw_optforfuzzing:
       B.addAttribute(Attribute::OptForFuzzing); break;
     case lltok::kw_optnone: B.addAttribute(Attribute::OptimizeNone); break;
+    case lltok::kw_optnoneall: B.addAttribute(Attribute::OptimizeNoneAll); break;
     case lltok::kw_optsize: B.addAttribute(Attribute::OptimizeForSize); break;
     case lltok::kw_readnone: B.addAttribute(Attribute::ReadNone); break;
     case lltok::kw_readonly: B.addAttribute(Attribute::ReadOnly); break;
@@ -1786,6 +1787,7 @@ bool LLParser::parseOptionalParamAttrs(AttrBuilder &B) {
     case lltok::kw_nounwind:
     case lltok::kw_optforfuzzing:
     case lltok::kw_optnone:
+    case lltok::kw_optnoneall:
     case lltok::kw_optsize:
     case lltok::kw_returns_twice:
     case lltok::kw_sanitize_address:
@@ -1895,6 +1897,7 @@ bool LLParser::parseOptionalReturnAttrs(AttrBuilder &B) {
     case lltok::kw_nounwind:
     case lltok::kw_optforfuzzing:
     case lltok::kw_optnone:
+    case lltok::kw_optnoneall:
     case lltok::kw_optsize:
     case lltok::kw_returns_twice:
     case lltok::kw_sanitize_address:

--- a/llvm/lib/AsmParser/LLToken.h
+++ b/llvm/lib/AsmParser/LLToken.h
@@ -219,6 +219,7 @@ enum Kind {
   kw_null_pointer_is_valid,
   kw_optforfuzzing,
   kw_optnone,
+  kw_optnoneall,
   kw_optsize,
   kw_preallocated,
   kw_readnone,

--- a/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
+++ b/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
@@ -1477,6 +1477,8 @@ static Attribute::AttrKind getAttrFromCode(uint64_t Code) {
     return Attribute::OptimizeForSize;
   case bitc::ATTR_KIND_OPTIMIZE_NONE:
     return Attribute::OptimizeNone;
+  case bitc::ATTR_KIND_OPTIMIZE_NONE_ALL:
+    return Attribute::OptimizeNoneAll;
   case bitc::ATTR_KIND_READ_NONE:
     return Attribute::ReadNone;
   case bitc::ATTR_KIND_READ_ONLY:

--- a/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
+++ b/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
@@ -692,6 +692,8 @@ static uint64_t getAttrKindEncoding(Attribute::AttrKind Kind) {
     return bitc::ATTR_KIND_OPTIMIZE_FOR_SIZE;
   case Attribute::OptimizeNone:
     return bitc::ATTR_KIND_OPTIMIZE_NONE;
+  case Attribute::OptimizeNoneAll:
+    return bitc::ATTR_KIND_OPTIMIZE_NONE_ALL;
   case Attribute::ReadNone:
     return bitc::ATTR_KIND_READ_NONE;
   case Attribute::ReadOnly:

--- a/llvm/lib/IR/Attributes.cpp
+++ b/llvm/lib/IR/Attributes.cpp
@@ -411,6 +411,8 @@ std::string Attribute::getAsString(bool InAttrGrp) const {
     return "optforfuzzing";
   if (hasAttribute(Attribute::OptimizeNone))
     return "optnone";
+  if (hasAttribute(Attribute::OptimizeNoneAll))
+    return "optnoneall";
   if (hasAttribute(Attribute::OptimizeForSize))
     return "optsize";
   if (hasAttribute(Attribute::ReadNone))

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -1637,6 +1637,7 @@ static bool isFuncOnlyAttr(Attribute::AttrKind Kind) {
   case Attribute::Hot:
   case Attribute::OptForFuzzing:
   case Attribute::OptimizeNone:
+  case Attribute::OptimizeNoneAll:
   case Attribute::JumpTable:
   case Attribute::Convergent:
   case Attribute::ArgMemOnly:
@@ -1945,6 +1946,20 @@ void Verifier::verifyFunctionAttrs(FunctionType *FT, AttributeList Attrs,
 
     Assert(!Attrs.hasFnAttribute(Attribute::MinSize),
            "Attributes 'minsize and optnone' are incompatible!", V);
+
+    Assert(!Attrs.hasFnAttribute(Attribute::OptimizeNoneAll),
+           "Attributes 'optnoneall and optnone' are incompatible!", V);
+  }
+
+  if (Attrs.hasFnAttribute(Attribute::OptimizeNoneAll)) {
+    Assert(Attrs.hasFnAttribute(Attribute::NoInline),
+           "Attribute 'optnoneall' requires 'noinline'!", V);
+
+    Assert(!Attrs.hasFnAttribute(Attribute::OptimizeForSize),
+           "Attributes 'optsize and optnoneall' are incompatible!", V);
+
+    Assert(!Attrs.hasFnAttribute(Attribute::MinSize),
+           "Attributes 'minsize and optnoneall' are incompatible!", V);
   }
 
   if (Attrs.hasFnAttribute(Attribute::JumpTable)) {

--- a/llvm/lib/Transforms/IPO/ForceFunctionAttrs.cpp
+++ b/llvm/lib/Transforms/IPO/ForceFunctionAttrs.cpp
@@ -55,6 +55,7 @@ static Attribute::AttrKind parseAttrKind(StringRef Kind) {
       .Case("nounwind", Attribute::NoUnwind)
       .Case("optforfuzzing", Attribute::OptForFuzzing)
       .Case("optnone", Attribute::OptimizeNone)
+      .Case("optnoneall", Attribute::OptimizeNoneAll)
       .Case("optsize", Attribute::OptimizeForSize)
       .Case("readnone", Attribute::ReadNone)
       .Case("readonly", Attribute::ReadOnly)


### PR DESCRIPTION
This is a draft. I want to check that this is what we had in mind before I embark on the task of finding all the places that the attribute should be checked.

## The change
```
The `optnoneall` function attribute will be like the `optnone` function
attribute, except that it additionally suppresses inter-procedural
optimisations (those passes found in the `llvm/lib/Transforms/IPO`
directory). `optnonall` will imply `optnone`.

This commit only adds the attribute. The attribute does nothing at the
moment.
```

## Complexity

Adding an attribute turns out to be quite involved, as there are many parts of the system that have to be taught about it (bc lexer, bc reader, bc writer, verifier, clang (optional, but useful)).

Some of these places I found myself. When it didn't work, I turned to searching the internet, and found [this guilde](https://www.cs.cmu.edu/~seth/llvm/llvmannotation.html).

A simpler, but arguably more hacky and less general, approach would be to simply recognise the control point function with a given prefix (e.g. `__yk_control_`). Then LLVM bitcode format and language remains the same throughout. Of course we may need to block optimisations for other functions later, in which case an attribute is the way to go.

## Questions

 * Is this roughly what we had in mind?
 * Should we write tests for this attribute at this stage?
 * Do we think this (once completed) should be up-streamed?