### PR TITLE
Return from direct recursion disambiguation

### DIFF
--- a/llvm/lib/Target/X86/X86FastISel.cpp
+++ b/llvm/lib/Target/X86/X86FastISel.cpp
@@ -2590,6 +2590,8 @@ bool X86FastISel::TryEmitSmallMemcpy(X86AddressMode DestAM,
 
 // Add an annotation to an intrinsic instruction, specifying whether the
 // intrinsic has been inlined or not.
+//
+// This is only necessary for intrinsics which may emit machine code.
 void annotateIntrinsic(const IntrinsicInst *II, bool Inlined) {
   IntrinsicInst *CI = const_cast<IntrinsicInst *>(II);
   LLVMContext& C = CI->getContext();

--- a/llvm/lib/Transforms/Yk/BlockDisambiguate.cpp
+++ b/llvm/lib/Transforms/Yk/BlockDisambiguate.cpp
@@ -245,8 +245,9 @@ public:
   }
 
 private:
-  BasicBlock *makeDisambiguationBB(LLVMContext &Context, BasicBlock *BB,
-                                   std::vector<BasicBlock *> &NewBBs) {
+  // Create a block for intra-function branch disambiguation.
+  BasicBlock *makeBranchDisambiguationBB(LLVMContext &Context, BasicBlock *BB,
+                                         std::vector<BasicBlock *> &NewBBs) {
     BasicBlock *DBB = BasicBlock::Create(Context, "");
     NewBBs.push_back(DBB);
     IRBuilder<> Builder(DBB);
@@ -269,7 +270,7 @@ private:
              SuccIdx++) {
           BasicBlock *SuccBB = BI->getSuccessor(SuccIdx);
           if (SuccBB == &BB) {
-            BasicBlock *DBB = makeDisambiguationBB(Context, &BB, NewBBs);
+            BasicBlock *DBB = makeBranchDisambiguationBB(Context, &BB, NewBBs);
             BI->setSuccessor(SuccIdx, DBB);
             BB.replacePhiUsesWith(&BB, DBB);
           }
@@ -280,7 +281,7 @@ private:
              SuccIdx++) {
           BasicBlock *SuccBB = SI->getSuccessor(SuccIdx);
           if (SuccBB == &BB) {
-            BasicBlock *DBB = makeDisambiguationBB(Context, &BB, NewBBs);
+            BasicBlock *DBB = makeBranchDisambiguationBB(Context, &BB, NewBBs);
             SI->setSuccessor(SuccIdx, DBB);
             BB.replacePhiUsesWith(&BB, DBB);
           }


### PR DESCRIPTION
This addresses an issue where the mapper collapses direct recursion (a function calling itself) bubbling up (confusing it for internal control flow at the machine basic block level).

This is involved.

I wouldn't recommend trying to understand what I've added without first reviewing the large module-level comment first. I expect this will be a task for Lukas, as it's unfair to ask Laurie to digest that stuff afresh.