### PR TITLE
Add the `yk_outline` function attribute.

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -3823,3 +3823,10 @@ def EnforceTCBLeaf : InheritableAttr {
   let Documentation = [EnforceTCBLeafDocs];
   bit InheritEvenIfAlreadyPresent = 1;
 }
+
+def YkOutline : InheritableAttr {
+  let Spellings = [GCC<"yk_outline">, Declspec<"yk_outline">];
+  let Subjects = SubjectList<[Function]>;
+  let Documentation = [YkOutlineDocs];
+  let SimpleHandler = 1;
+}

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -6045,3 +6045,11 @@ def EnforceTCBLeafDocs : Documentation {
   - ``enforce_tcb_leaf(Name)`` indicates that this function is a part of the TCB named ``Name``
   }];
 }
+
+def YkOutlineDocs : Documentation {
+  let Category = DocCatFunction;
+  let Content = [{
+  The ``yk_outline`` attribute tells the Yk JIT to outline (not inline) calls
+  to the annotated function.
+  }];
+}

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -1868,6 +1868,13 @@ void CodeGenModule::SetLLVMFunctionAttributesForDefinition(const Decl *D,
       B.addAttribute(llvm::Attribute::MinSize);
   }
 
+  if (D->hasAttr<YkOutlineAttr>()) {
+    // Prevent the Yk trace compiler from inlining the call.
+    B.addAttribute("yk_outline");
+    // Prevent LLVM from inlining the call when optimising the trace.
+    B.addAttribute(llvm::Attribute::NoInline);
+  }
+
   F->addAttributes(llvm::AttributeList::FunctionIndex, B);
 
   unsigned alignment = D->getMaxAlignment() / Context.getCharWidth();

--- a/clang/test/Misc/pragma-attribute-supported-attributes-list.test
+++ b/clang/test/Misc/pragma-attribute-supported-attributes-list.test
@@ -185,4 +185,5 @@
 // CHECK-NEXT: WorkGroupSizeHint (SubjectMatchRule_function)
 // CHECK-NEXT: XRayInstrument (SubjectMatchRule_function, SubjectMatchRule_objc_method)
 // CHECK-NEXT: XRayLogArgs (SubjectMatchRule_function, SubjectMatchRule_objc_method)
+// CHECK-NEXT: YkOutline (SubjectMatchRule_function)
 // CHECK-NEXT: End of supported attributes.


### PR DESCRIPTION
This annotations does two things:

 - It tells the Yk JIT to *not* inline calls to the function in into JIT
   traces.

 - It adds the `noinline` attribute, thus preventing LLVM from inlining
   calls to the function when compiling JIT traces.

A `yk` companion PR ~will come soon~ is [here](https://github.com/ykjit/yk/pull/531).

Merge the companion PR last.

Raising as a draft, because I'm now questioning the name of the annotation.

"do not trace" feels weird in the context of the hardware tracer. PT will always trace everything, whether we like it or not, and then our annotation retroactively un-inlines (outlines) the inlined code. So is `yk-outline` a better annotation name for us?