### PR TITLE
Force emission of a branch in FastISel.

### DIFF
--- a/llvm/lib/CodeGen/CodeGen.cpp
+++ b/llvm/lib/CodeGen/CodeGen.cpp
@@ -14,8 +14,15 @@
 #include "llvm-c/Initialization.h"
 #include "llvm/InitializePasses.h"
 #include "llvm/PassRegistry.h"
+#include "llvm/Support/CommandLine.h"
 
 using namespace llvm;
+
+llvm::cl::opt<bool> YkNoFallThrough(
+    "yk-no-fallthrough", cl::Hidden, cl::init(false),
+    cl::desc("Always emit a branch even if fallthrough is possible. This "
+             "is required for the yk JIT, so that the machine IR has the "
+             "same block structure as the high-level IR"));
 
 /// initializeCodeGen - Initialize all passes linked into the CodeGen library.
 void llvm::initializeCodeGen(PassRegistry &Registry) {

--- a/llvm/lib/CodeGen/SelectionDAG/FastISel.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/FastISel.cpp
@@ -111,6 +111,8 @@
 using namespace llvm;
 using namespace PatternMatch;
 
+extern cl::opt<bool> YkNoFallThrough;
+
 #define DEBUG_TYPE "isel"
 
 STATISTIC(NumFastIselSuccessIndependent, "Number of insts selected by "
@@ -1576,7 +1578,7 @@ bool FastISel::selectInstruction(const Instruction *I) {
 /// (fall-through) successor, and update the CFG.
 void FastISel::fastEmitBranch(MachineBasicBlock *MSucc,
                               const DebugLoc &DbgLoc) {
-  if (FuncInfo.MBB->getBasicBlock()->sizeWithoutDebug() > 1 &&
+  if ((!YkNoFallThrough) && (FuncInfo.MBB->getBasicBlock()->sizeWithoutDebug() > 1) &&
       FuncInfo.MBB->isLayoutSuccessor(MSucc)) {
     // For more accurate line information if this is the only non-debug
     // instruction in the block then emit it, otherwise we have the

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -135,11 +135,7 @@ static cl::opt<unsigned> SwitchPeelThreshold(
              "switch statement. A value greater than 100 will void this "
              "optimization"));
 
-static cl::opt<bool> YkNoFallThrough(
-    "yk-no-fallthrough", cl::Hidden, cl::init(false),
-    cl::desc("Always emit a branch even if fallthrough is possible. This "
-             "is required for the yk JIT, so that the machine IR has the "
-             "same block structure as the high-level IR"));
+extern cl::opt<bool> YkNoFallThrough;
 
 // Limit the width of DAG chains. This is important in general to prevent
 // DAG-based analysis from blowing up. For example, alias analysis and


### PR DESCRIPTION
This is similar to #29, but for FastISel. The change ensures that a LLVM
`br` always codegens a branch, even if fallthrough is possible.

We re-use --yk-no-fallthrough for this. To do so we move its definition
into a more generic location.

With this, the Lua interpreter runs until stop-gapping with the yk JIT.