### PR TITLE
In debug builds, verify the IR after the control point pass.

### DIFF
--- a/llvm/lib/Transforms/Yk/ControlPoint.cpp
+++ b/llvm/lib/Transforms/Yk/ControlPoint.cpp
@@ -257,7 +257,14 @@ public:
     Builder.SetInsertPoint(BB);
     Builder.CreateCondBr(NewCtrlPointCallInst, ExitBB, ContBB);
 
-    // Generate new control point logic.
+#ifndef NDEBUG
+    // Our pass runs after LLVM normally does its verify pass. In debug builds
+    // we run it again to check that our pass is generating valid IR.
+    if (verifyModule(M, &errs())) {
+      Context.emitError("Control point pass generated invalid IR!");
+      return false;
+    }
+#endif
     return true;
   }
 };


### PR DESCRIPTION
Sometimes we were letting through invalid IR, which may or may not be
detected at runtime.

(Oddly `parseIR()` doesn't always detect invalid IR, even with
assertions on!)

Companion PR [here](https://github.com/ykjit/yk/pull/538).