### PR TITLE
Allow arbitrary return types in control points caller.

### DIFF
--- a/llvm/lib/Transforms/Yk/ControlPoint.cpp
+++ b/llvm/lib/Transforms/Yk/ControlPoint.cpp
@@ -363,7 +363,12 @@ public:
     Builder.SetInsertPoint(ExitBB);
     // YKFIXME: We need to return the value of interpreted return and the return
     // type must be that of the control point's caller.
-    Builder.CreateRet(ConstantInt::get(Type::getInt32Ty(Context), 0));
+    Type *RetTy = Caller->getReturnType();
+    if (RetTy->isVoidTy()) {
+      Builder.CreateRetVoid();
+    } else {
+      Builder.CreateRet(ConstantInt::get(Type::getInt32Ty(Context), 0));
+    }
 
     // To do so we need to first split up the current block and then
     // insert a conditional branch that either continues or returns.


### PR DESCRIPTION
Updates the control point pass to allocate some space in which the stopgap interpreter will store the value of the interpreter return, when it runs outside of the main interpreter loop during a guard failure.

Companion PR: https://github.com/ykjit/yk/pull/551
