### PR TITLE
Add the `yk_unroll_safe` attribute.

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -4072,3 +4072,10 @@ def YkOutline : InheritableAttr {
   let Documentation = [YkOutlineDocs];
   let SimpleHandler = 1;
 }
+
+def YkUnrollSafe : InheritableAttr {
+  let Spellings = [GCC<"yk_unroll_safe">, Declspec<"yk_unroll_safe">];
+  let Subjects = SubjectList<[Function]>;
+  let Documentation = [YkUnrollSafeDocs];
+  let SimpleHandler = 1;
+}

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -6667,3 +6667,12 @@ def YkOutlineDocs : Documentation {
   to the annotated function.
   }];
 }
+
+def YkUnrollSafeDocs : Documentation {
+  let Category = DocCatFunction;
+  let Content = [{
+  The ``yk_unroll_safe`` attribute tells the Yk JIT that during tracing, calls
+  to the annotated function can be inlined, even if it contains loops. By
+  default only calls to functions that contain no loops are inlined.
+  }];
+}

--- a/clang/include/clang/Basic/CodeGenOptions.def
+++ b/clang/include/clang/Basic/CodeGenOptions.def
@@ -333,6 +333,8 @@ CODEGENOPT(DebugColumnInfo, 1, 0) ///< Whether or not to use column information
 CODEGENOPT(DebugTypeExtRefs, 1, 0) ///< Whether or not debug info should contain
                                    ///< external references to a PCH or module.
 
+CODEGENOPT(YkNoinlineFuncsWithLoops, 1, 0) ///< Yk JIT: by default don't inline functions
+                                           ///< containing loops.
 CODEGENOPT(DebugExplicitImport, 1, 0)  ///< Whether or not debug info should
                                        ///< contain explicit imports for
                                        ///< anonymous namespaces

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -4739,6 +4739,11 @@ def finline_limit_EQ : Joined<["-"], "finline-limit=">, Group<clang_ignored_gcc_
 defm finline_limit : BooleanFFlag<"inline-limit">, Group<clang_ignored_gcc_optimization_f_Group>;
 defm inline_small_functions : BooleanFFlag<"inline-small-functions">,
     Group<clang_ignored_gcc_optimization_f_Group>;
+defm yk_noinline_funcs_with_loops : BoolOption<"f", "yk-noinline-funcs-with-loops",
+  CodeGenOpts<"YkNoinlineFuncsWithLoops">, DefaultFalse,
+  NegFlag<SetFalse, []>,
+  PosFlag<SetTrue, [], "Don't inline functions containing loops by default (used for the Yk JIT).">,
+  BothFlags<[CC1Option, CoreOption]>>;
 defm ipa_cp : BooleanFFlag<"ipa-cp">,
     Group<clang_ignored_gcc_optimization_f_Group>;
 defm ivopts : BooleanFFlag<"ivopts">, Group<clang_ignored_gcc_optimization_f_Group>;

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5399,6 +5399,10 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
   else if (UnwindTables)
     CmdArgs.push_back("-funwind-tables=1");
 
+  if (Args.hasFlag(options::OPT_fyk_noinline_funcs_with_loops,
+                   options::OPT_fno_yk_noinline_funcs_with_loops, false))
+    CmdArgs.push_back("-fyk-noinline-funcs-with-loops");
+
   // Prepare `-aux-target-cpu` and `-aux-target-feature` unless
   // `--gpu-use-aux-triple-only` is specified.
   if (!Args.getLastArg(options::OPT_gpu_use_aux_triple_only) &&

--- a/clang/test/Misc/pragma-attribute-supported-attributes-list.test
+++ b/clang/test/Misc/pragma-attribute-supported-attributes-list.test
@@ -197,5 +197,6 @@
 // CHECK-NEXT: XRayInstrument (SubjectMatchRule_function, SubjectMatchRule_objc_method)
 // CHECK-NEXT: XRayLogArgs (SubjectMatchRule_function, SubjectMatchRule_objc_method)
 // CHECK-NEXT: YkOutline (SubjectMatchRule_function)
+// CHECK-NEXT: YkUnrollSafe (SubjectMatchRule_function)
 // CHECK-NEXT: ZeroCallUsedRegs (SubjectMatchRule_function)
 // CHECK-NEXT: End of supported attributes.

--- a/clang/test/Yk/yk_noinline_loopy_funcs.c
+++ b/clang/test/Yk/yk_noinline_loopy_funcs.c
@@ -1,0 +1,15 @@
+// RUN: %clang -emit-llvm -fyk-noinline-funcs-with-loops -c -O0 -o - %s | llvm-dis | grep "call .*@never_aot_inline("
+// RUN: %clang -emit-llvm -fyk-noinline-funcs-with-loops -c -O1 -o - %s | llvm-dis | grep "call .*@never_aot_inline("
+// RUN: %clang -emit-llvm -fyk-noinline-funcs-with-loops -c -O2 -o - %s | llvm-dis | grep "call .*@never_aot_inline("
+// RUN: %clang -emit-llvm -fyk-noinline-funcs-with-loops -c -O3 -o - %s | llvm-dis | grep "call .*@never_aot_inline("
+
+#include <stdio.h>
+
+static void never_aot_inline(int i) {
+  while (i--)
+    putchar('.');
+}
+
+int main(int argc, char **argv) {
+  never_aot_inline(argc);
+}


### PR DESCRIPTION
This function attribute tells the Yk JIT that it is OK to inline the decorated function into the trace, even if it contains loops.

It follows that from now on, any function containing a loop will not be inlined into traces by default.

This change also introduces an "internal" `__yk_hasloop` annotation, which is used by the JIT to know if a function contains loops.

**A companion PR will follow**

# Why a draft?

This change adds one *clang* attribute:
 - `yk_unroll_safe`

And adds two *llvm* attributes:
 - `yk_unroll_safe`
 - `__yk_has_loop`

Just as I am raising this PR, I realise that I can simplify things: the clang `yk_unroll_safe` annotation could lower to the existing llvm `yk_outline` annotation and we can also only apply this annotation if the function has no loops, thus making `__yk_has_loop` redundant too.

This plan assumes that it is not important to make a distinction between `yk_outline` and `yk_unroll_safe` at the LLVM IR level. Is that so?