### PR TITLE
Add the `-yk-alloc-llvmbc-section` flag.

### DIFF
--- a/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
+++ b/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
@@ -70,6 +70,8 @@
 using namespace llvm;
 using namespace dwarf;
 
+extern bool YkAllocLLVMBCSection;
+
 static void GetObjCImageInfo(Module &M, unsigned &Version, unsigned &Flags,
                              StringRef &Section) {
   SmallVector<Module::ModuleFlagEntry, 8> ModuleFlags;
@@ -786,6 +788,12 @@ static MCSection *selectExplicitSectionGlobal(
       Retain, ForceUnique);
 
   const MCSymbolELF *LinkedToSym = getLinkedToSymbol(GO, TM);
+
+  // The Yk JIT expects to load the IR from its address space. This tells the
+  // loader to load the section.
+  if (YkAllocLLVMBCSection && (SectionName == ".llvmbc"))
+    Flags |= llvm::ELF::SHF_ALLOC;
+
   MCSectionELF *Section = Ctx.getELFSection(
       SectionName, getELFSectionType(SectionName, Kind), Flags, EntrySize,
       Group, IsComdat, UniqueID, LinkedToSym);

--- a/llvm/lib/Support/CMakeLists.txt
+++ b/llvm/lib/Support/CMakeLists.txt
@@ -236,6 +236,7 @@ add_llvm_component_library(LLVMSupport
   X86TargetParser.cpp
   YAMLParser.cpp
   YAMLTraits.cpp
+  Yk.cpp
   raw_os_ostream.cpp
   raw_ostream.cpp
   regcomp.c

--- a/llvm/lib/Support/Yk.cpp
+++ b/llvm/lib/Support/Yk.cpp
@@ -1,0 +1,8 @@
+#include "llvm/Support/CommandLine.h"
+
+using namespace llvm;
+
+bool YkAllocLLVMBCSection;
+static cl::opt<bool, true> YkAllocLLVMBCSectionParser(
+    "yk-alloc-llvmbc-section", cl::desc("Make the `.llvmbc` section loadable"),
+    cl::NotHidden, cl::location(YkAllocLLVMBCSection));


### PR DESCRIPTION
Enabling this flag does three things:

 - Adds the `SHF_ALLOC` flag to the `.llvmbc` section so that it gets loaded by the loader.

 - Makes the `llvm.embedded.module` symbol inside externally visible by giving it external linkage.

 - Prepends the embedded IR with a pointer-sized length field so that we can load the IR directly from memory at runtime.

I was having issues finding a place to define the flag where it could be consistently accessed across the necessary module linkage boundaries. I've ended up defining  it in `llvm/lib/Support`, which is an "always linked" component.