### PR TITLE
Make it so we can read the `.llvm_bb_addr_map` section from memory at runtime

### DIFF
--- a/llvm/lib/MC/MCObjectFileInfo.cpp
+++ b/llvm/lib/MC/MCObjectFileInfo.cpp
@@ -1120,6 +1120,8 @@ MCObjectFileInfo::getStackSizesSection(const MCSection &TextSec) const {
                             cast<MCSymbolELF>(TextSec.getBeginSymbol()));
 }
 
+extern bool YkAllocLLVMBBAddrMapSection;
+
 MCSection *
 MCObjectFileInfo::getBBAddrMapSection(const MCSection &TextSec) const {
   if (Ctx->getObjectFileType() != MCContext::IsELF)
@@ -1132,6 +1134,9 @@ MCObjectFileInfo::getBBAddrMapSection(const MCSection &TextSec) const {
     GroupName = Group->getName();
     Flags |= ELF::SHF_GROUP;
   }
+
+  if (YkAllocLLVMBBAddrMapSection)
+    Flags |= ELF::SHF_ALLOC;
 
   // Use the text section's begin symbol and unique ID to create a separate
   // .llvm_bb_addr_map section associated with every unique text section.

--- a/llvm/lib/Support/Yk.cpp
+++ b/llvm/lib/Support/Yk.cpp
@@ -6,3 +6,9 @@ bool YkAllocLLVMBCSection;
 static cl::opt<bool, true> YkAllocLLVMBCSectionParser(
     "yk-alloc-llvmbc-section", cl::desc("Make the `.llvmbc` section loadable"),
     cl::NotHidden, cl::location(YkAllocLLVMBCSection));
+
+bool YkAllocLLVMBBAddrMapSection;
+static cl::opt<bool, true> YkAllocLLVMBBAddrMapSectionParser(
+    "yk-alloc-llvmbbaddrmap-section",
+    cl::desc("Make the `.llvmbbaddrmap` section loadable"), cl::NotHidden,
+    cl::location(YkAllocLLVMBBAddrMapSection));


### PR DESCRIPTION
[Companion PR: ~for the runtime coming soon~ https://github.com/ykjit/yk/pull/571]

We make the section loadable and emit symbols to help us find the data at runtime.

LLVM streams the BB data for each function (independently) out to the binary on the fly. This makes it hard to provide the runtime with a simple `(address, length)` pair that it needs to make a Rust slice of the data.

We work around this like so: for each function we emit a start and end symbol marking the bbaddrmap data for the function. The name of the symbol encodes the function for which the BB data corresponds. The runtime knows what functions are available (from the LTO LLVM IR) and can therefore enumerate the symbols to find all of the BB data.