### PR TITLE
Add function prologue info to stackmaps.

### DIFF
--- a/llvm/include/llvm/Transforms/Yk/ControlPoint.h
+++ b/llvm/include/llvm/Transforms/Yk/ControlPoint.h
@@ -10,6 +10,10 @@
 // The name of the new control point replacing the user's dummy control point.
 #define YK_NEW_CONTROL_POINT "__ykrt_control_point"
 
+// The name of the function which reconstructs the stackframe and jumps to the
+// right instruction in AOT from where to continue.
+#define YK_RECONSTRUCT_FRAMES "__ykrt_reconstruct_frames"
+
 namespace llvm {
 ModulePass *createYkControlPointPass();
 } // namespace llvm

--- a/llvm/test/CodeGen/X86/statepoint-stackmap-size.ll
+++ b/llvm/test/CodeGen/X86/statepoint-stackmap-size.ll
@@ -4,7 +4,7 @@
 ; spaces) starting with a `.` follow (e.g. `  .byte`).
 ;
 ;      CHECK:	.section	.llvm_stackmaps,{{.*$}}
-; CHECK-NEXT:{{(.+$[[:space:]]){51}[[:space:]]}}
+; CHECK-NEXT:{{(.+$[[:space:]]){54}[[:space:]]}}
 ;  CHECK-NOT:{{.|[[:space:]]}}
 
 target triple = "x86_64-pc-linux-gnu"


### PR DESCRIPTION
This is a companion PR to https://github.com/ykjit/yk/pull/578 and adds function prologue information (e.g. callee-saved registers, pushed RBP) to stackmaps, which are required in order to do stack reconstruction during guard failures.