### PR TITLE
Switch to section start/stop markers for the `.llvm_bb_addr_map` section.

### DIFF
--- a/llvm/include/llvm/CodeGen/AsmPrinter.h
+++ b/llvm/include/llvm/CodeGen/AsmPrinter.h
@@ -226,6 +226,13 @@ private:
   /// split stack prologue.
   bool HasNoSplitStack = false;
 
+  /// `true` when the `.llvm_bb_addr_map` section is going to be loaded at
+  /// runtime and we've emitted at least one entry.
+  bool YkEmittedFirstBBAddrMap = false;
+
+  /// The last `.llvm_bb_addr_map` section fragment that we handled (if any).
+  MCSection *YkLastBBAddrMapSection = nullptr;
+
 protected:
   explicit AsmPrinter(TargetMachine &TM, std::unique_ptr<MCStreamer> Streamer);
 


### PR DESCRIPTION
Prior to this change, each *function* would get a start/stop symbol pair and the runtime would need to know the names of all the functions in order to load each map from the `.llvm_bb_addr_map` section.

The problem with that approach is that to know the names of all of the functions, you need to also have the LLVM IR in order to iterate over the functions in the module. To do that, you need to have the LLVM IR parser, which means linking LLVM.

In upcoming work (for the fast ykpt trace decoder), the block map parser will need to be moved out of `yk` and into `hwtracer`, so that hwtracer can pick up the decoding hints we are going to add to the block map.

It seems unreasonable and cumbersome for `hwtracer` to have to link LLVM just to load the blockmap.

This change uses *section* start and stop symbols (instead of per-function start/stop symbols), so that `hwtracer` will be able to load the whole blockmap section without any knowledge of LLVM IR.

It is probably also a bit quicker at runtime, since we no longer need to iterate over the functions in the IR and load their maps individually.

(The approach assumes that LTO is being used, which is already a requirement of Yk).

Companion PR ~~coming soon~~ [here](https://github.com/ykjit/yk/pull/583)