### PR TITLE
Extend the .llvm_bb_addr_map section with PT decoding hints.

### DIFF
--- a/llvm/include/llvm/CodeGen/AsmPrinter.h
+++ b/llvm/include/llvm/CodeGen/AsmPrinter.h
@@ -233,6 +233,11 @@ private:
   /// The last `.llvm_bb_addr_map` section fragment that we handled (if any).
   MCSection *YkLastBBAddrMapSection = nullptr;
 
+  /// Symbols marking the call instructions of each block. Used for the Yk JIT.
+  std::map<const MachineBasicBlock *,
+           SmallVector<std::tuple<MCSymbol *, MCSymbol *>>>
+      YkCallMarkerSyms;
+
 protected:
   explicit AsmPrinter(TargetMachine &TM, std::unique_ptr<MCStreamer> Streamer);
 

--- a/llvm/test/CodeGen/X86/basic-block-sections-labels.ll
+++ b/llvm/test/CodeGen/X86/basic-block-sections-labels.ll
@@ -55,18 +55,21 @@ declare i32 @__gxx_personality_v0(...)
 ; CHECK-NEXT:	.byte	8
 ; CHECK-NEXT:	.byte	1
 ; CHECK-NEXT:	.byte	0
-; CHECK-NEXT:	.uleb128 .LBB0_1-.LBB_END0_0
+; ...calls and successor info for Yk JIT...
+; CHECK:	.uleb128 .LBB0_1-.LBB_END0_0
 ; CHECK-NEXT:	.uleb128 .LBB_END0_1-.LBB0_1
 ; CHECK-NEXT:	.byte	8
 ; CHECK-NEXT:	.byte	1
 ; CHECK-NEXT:	.byte	1
-; CHECK-NEXT:	.uleb128 .LBB0_2-.LBB_END0_1
+; ...calls and successor info for Yk JIT...
+; CHECK:	.uleb128 .LBB0_2-.LBB_END0_1
 ; CHECK-NEXT:	.uleb128 .LBB_END0_2-.LBB0_2
 ; CHECK-NEXT:	.byte	1
 ; CHECK-NEXT:	.byte	2
 ; CHECK-NEXT:	.byte	3
 ; CHECK-NEXT:	.byte	4
-; CHECK-NEXT:	.uleb128 .LBB0_3-.LBB_END0_2
+; ...calls and successor info for Yk JIT...
+; CHECK:	.uleb128 .LBB0_3-.LBB_END0_2
 ; CHECK-NEXT:	.uleb128 .LBB_END0_3-.LBB0_3
 ; CHECK-NEXT:	.byte	5
 ; CHECK-NEXT:	.byte	2


### PR DESCRIPTION
This change does a couple of things. For each basic block we add:
 - A table of call offsets.
 - Information about statically known successors.

 In combination, this gives us enough information for a PT decoder
 (specifically our ykpt decoder) to make sense of a PT packet stream
 without the need to do static disassembly of the instruction steam
 (which would be slow).

 Note that to get the call offsets, we have to insert symbols into the
 binary, and their presence would break a lot of upstream LLVM tests.
 For now I've gated the insertion of the symbols in with
 `YkAllocBBAddrMapSection`.

 I've noticed that our .llvm_bb_addr_map extension have not been gated.
 My next change should probably be an all-encompassing
 `YkExtendedAddrMap` gate, which encompasses all of our addr map
 changes.

Companion to https://github.com/ykjit/yk/pull/585