### PR TITLE
blockmap: Split apart return edges from other dynamic edges.

### DIFF
--- a/llvm/include/llvm/CodeGen/TargetInstrInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetInstrInfo.h
@@ -1444,6 +1444,16 @@ public:
     return false;
   }
 
+  /// Returns true if MI is a far call.
+  ///
+  /// YKFIXME: x86 only.
+  virtual bool isFarCall(const MachineInstr &MI) const { return false; }
+
+  /// Returns true if MI is a far return.
+  ///
+  /// YKFIXME: x86 only.
+  virtual bool isFarRet(const MachineInstr &MI) const { return false; }
+
   /// Returns true if the tail call can be made conditional on BranchCond.
   virtual bool canMakeTailCallConditional(SmallVectorImpl<MachineOperand> &Cond,
                                           const MachineInstr &TailCall) const {

--- a/llvm/lib/Target/X86/X86InstrInfo.cpp
+++ b/llvm/lib/Target/X86/X86InstrInfo.cpp
@@ -2913,6 +2913,33 @@ bool X86InstrInfo::isUnconditionalTailCall(const MachineInstr &MI) const {
   }
 }
 
+bool X86InstrInfo::isFarCall(const MachineInstr &MI) const {
+  switch (MI.getOpcode()) {
+  case X86::FARCALL16i:
+  case X86::FARCALL16m:
+  case X86::FARCALL32i:
+  case X86::FARCALL32m:
+  case X86::FARCALL64m:
+    return true;
+  default:
+    return false;
+  }
+}
+
+bool X86InstrInfo::isFarRet(const MachineInstr &MI) const {
+  switch (MI.getOpcode()) {
+  case X86::LRET16:
+  case X86::LRET32:
+  case X86::LRET64:
+  case X86::LRETI16:
+  case X86::LRETI32:
+  case X86::LRETI64:
+    return true;
+  default:
+    return false;
+  }
+}
+
 bool X86InstrInfo::canMakeTailCallConditional(
     SmallVectorImpl<MachineOperand> &BranchCond,
     const MachineInstr &TailCall) const {

--- a/llvm/lib/Target/X86/X86InstrInfo.h
+++ b/llvm/lib/Target/X86/X86InstrInfo.h
@@ -316,6 +316,8 @@ public:
 
   // Branch analysis.
   bool isUnconditionalTailCall(const MachineInstr &MI) const override;
+  bool isFarCall(const MachineInstr &MI) const override;
+  bool isFarRet(const MachineInstr &MI) const override;
   bool canMakeTailCallConditional(SmallVectorImpl<MachineOperand> &Cond,
                                   const MachineInstr &TailCall) const override;
   void replaceBranchWithTailCall(MachineBasicBlock &MBB,


### PR DESCRIPTION
This is required for dealing with compressed returns in the ykpt decoder.

Companion to https://github.com/ykjit/yk/pull/590