### PR TITLE
Enable stackmap support for tracking multiple locations.

### DIFF
--- a/llvm/include/llvm/CodeGen/StackMaps.h
+++ b/llvm/include/llvm/CodeGen/StackMaps.h
@@ -285,7 +285,7 @@ public:
   /// Generate a stackmap record for a stackmap instruction.
   ///
   /// MI must be a raw STACKMAP, not a PATCHPOINT.
-  void recordStackMap(const MCSymbol &L, const MachineInstr &MI);
+  void recordStackMap(const MCSymbol &L, const MachineInstr &MI, std::map<Register, int64_t> SpillsOffsets = {});
 
   /// Generate a stackmap record for a patchpoint instruction.
   void recordPatchPoint(const MCSymbol &L, const MachineInstr &MI);
@@ -316,7 +316,8 @@ private:
   MachineInstr::const_mop_iterator
   parseOperand(MachineInstr::const_mop_iterator MOI,
                MachineInstr::const_mop_iterator MOE, LiveVarsVec &LiveVars,
-               LiveOutVec &LiveOuts) const;
+               LiveOutVec &LiveOuts,
+               std::map<Register, int64_t> SpillOffsets = {}) const;
 
   /// Specialized parser of statepoint operands.
   /// They do not directly correspond to StackMap record entries.
@@ -343,6 +344,7 @@ private:
   void recordStackMapOpers(const MCSymbol &L, const MachineInstr &MI,
                            uint64_t ID, MachineInstr::const_mop_iterator MOI,
                            MachineInstr::const_mop_iterator MOE,
+                           std::map<Register, int64_t> SpillOffsets = {},
                            bool recordResult = false);
 
   /// Emit the stackmap header.

--- a/llvm/lib/Support/Yk.cpp
+++ b/llvm/lib/Support/Yk.cpp
@@ -25,3 +25,9 @@ static cl::opt<bool, true> YkStackMapOffsetFixParser(
     cl::desc("Apply a fix to stackmaps that corrects the reported instruction "
              "offset in the presence of calls."),
     cl::NotHidden, cl::location(YkStackMapOffsetFix));
+
+bool YkStackMapAdditionalLocs;
+static cl::opt<bool, true> YkStackMapAdditionalLocsParser(
+    "yk-stackmap-add-locs",
+    cl::desc("Encode additional locations for registers into stackmaps."),
+    cl::NotHidden, cl::location(YkStackMapAdditionalLocs));

--- a/llvm/lib/Target/X86/X86AsmPrinter.h
+++ b/llvm/lib/Target/X86/X86AsmPrinter.h
@@ -71,6 +71,8 @@ class LLVM_LIBRARY_VISIBILITY X86AsmPrinter : public AsmPrinter {
   };
 
   StackMapShadowTracker SMShadowTracker;
+  // Map holding information about register spills.
+  std::map<const MachineInstr *, std::map<Register, int64_t>> StackmapSpillMaps;
 
   // All instructions emitted by the X86AsmPrinter should use this helper
   // method.

--- a/llvm/lib/Target/X86/X86MCInstLower.cpp
+++ b/llvm/lib/Target/X86/X86MCInstLower.cpp
@@ -1502,7 +1502,7 @@ void X86AsmPrinter::LowerSTACKMAP(const MachineInstr &MI) {
     MILabel = Ctx.createTempSymbol();
     OutStreamer->emitLabel(MILabel);
   }
-  SM.recordStackMap(*MILabel, MI);
+  SM.recordStackMap(*MILabel, MI, StackmapSpillMaps[&MI]);
   unsigned NumShadowBytes = MI.getOperand(1).getImm();
   SMShadowTracker.reset(NumShadowBytes);
 }

--- a/llvm/lib/Transforms/Yk/StackMaps.cpp
+++ b/llvm/lib/Transforms/Yk/StackMaps.cpp
@@ -56,9 +56,10 @@ public:
             CallInst &CI = cast<CallInst>(I);
             if (CI.isInlineAsm())
               continue;
-            if (CI.isIndirectCall())
-              continue;
-            if (CI.getCalledFunction()->isIntrinsic())
+            // We don't need to insert stackmaps after intrinsics. But since we
+            // can't tell if an indirect call is an intrinsic at compile time,
+            // emit a stackmap in those cases too.
+            if (!CI.isIndirectCall() && CI.getCalledFunction()->isIntrinsic())
               continue;
             SMCalls.insert({&I, LA.getLiveVarsBefore(&I)});
           } else if ((isa<BranchInst>(I) &&


### PR DESCRIPTION
Currently, stackmaps can only track one location per live variable, e.g. from the view of the stackmap a live variable is either in a register or on the stack. When deoptimising into machine code, this isn't sufficient since spilling will often create copies of a variable in multiple locations. This PR extends stackmaps to track an additional location for live variables in registers, i.e. in additional to the register location there can be another register location or a stack offset.

Note, that this makes some assumptions that may not hold in the general case, but will get us going on our way to fully trace Lua. We might have come back to revisit this code, if issues arise later on.