### PR TITLE
Apply stackmap mappings transitively.

### DIFF
--- a/llvm/lib/Target/X86/X86AsmPrinter.cpp
+++ b/llvm/lib/Target/X86/X86AsmPrinter.cpp
@@ -97,7 +97,17 @@ void processInstructions(
       const MachineOperand Rhs = Instr.getOperand(1);
       assert(Lhs.isReg() && "Is register.");
       assert(Rhs.isReg() && "Is register.");
-      SpillMap[Lhs.getReg()] = Rhs.getReg();
+      if (SpillMap.count(Rhs.getReg()) > 0) {
+        // If the RHS has a mapping, apply the same mapping to the new register.
+        // This means, that stack spills moved into one register and then into
+        // another will continued to be tracked.
+        SpillMap[Lhs.getReg()] = SpillMap[Rhs.getReg()];
+      } else {
+        SpillMap[Lhs.getReg()] = Rhs.getReg();
+      }
+      // YKFIXME: If the `mov` instruction has a killed-flag, remove the
+      // register from the map.
+
       // Reassigning a new value to Lhs means any mappings to Lhs are now void
       // and need to be removed.
       clearRhs(Lhs.getReg(), SpillMap);

--- a/llvm/lib/Transforms/Yk/ControlPoint.cpp
+++ b/llvm/lib/Transforms/Yk/ControlPoint.cpp
@@ -220,10 +220,6 @@ public:
     // Replace the call to the dummy control point.
     OldCtrlPointCall->eraseFromParent();
 
-    // Get the result of the control point call. If it returns true, that means
-    // the stopgap interpreter has interpreted a return so we need to return as
-    // well.
-
     // Create the new exit block.
     BasicBlock *ExitBB = BasicBlock::Create(Context, "", Caller);
     Builder.SetInsertPoint(ExitBB);


### PR DESCRIPTION
If a register has a mapping and is then mapped to a new register, apply the same mapping to the new register. This means, that stack spills moved into one register and then into another will continued to be tracked.

While we are here, remove an old and now irrelevant comment.