### PR TITLE
Fix changes to stackmaps made by the register allocator.

### DIFF
--- a/llvm/include/llvm/CodeGen/Passes.h
+++ b/llvm/include/llvm/CodeGen/Passes.h
@@ -571,6 +571,11 @@ namespace llvm {
   /// caller saved registers with stack slots.
   extern char &FixupStatepointCallerSavedID;
 
+  /// This pass fixes stackmaps by moving the STACKMAP instruction back to its
+  /// pre-regalloc location, and reverting its operands back to the original
+  /// values (before spill reloads).
+  extern char &FixStackmapsSpillReloadsID;
+
   /// The pass transforms load/store <256 x i32> to AMX load/store intrinsics
   /// or split the data to two <128 x i32>.
   FunctionPass *createX86LowerAMXTypePass();

--- a/llvm/include/llvm/InitializePasses.h
+++ b/llvm/include/llvm/InitializePasses.h
@@ -139,6 +139,7 @@ void initializeFinalizeISelPass(PassRegistry&);
 void initializeFinalizeMachineBundlesPass(PassRegistry&);
 void initializeFixIrreduciblePass(PassRegistry &);
 void initializeFixupStatepointCallerSavedPass(PassRegistry&);
+void initializeFixStackmapsSpillReloadsPass(PassRegistry&);
 void initializeFlattenCFGLegacyPassPass(PassRegistry &);
 void initializeFloat2IntLegacyPassPass(PassRegistry&);
 void initializeForceFunctionAttrsLegacyPassPass(PassRegistry&);

--- a/llvm/lib/CodeGen/CMakeLists.txt
+++ b/llvm/lib/CodeGen/CMakeLists.txt
@@ -216,6 +216,7 @@ add_llvm_component_library(LLVMCodeGen
   StackFrameLayoutAnalysisPass.cpp
   StackMapLivenessAnalysis.cpp
   StackMaps.cpp
+  Yk/FixStackmapsSpillReloads.cpp
   StackProtector.cpp
   StackSlotColoring.cpp
   SwiftErrorValueTracking.cpp

--- a/llvm/lib/CodeGen/CodeGen.cpp
+++ b/llvm/lib/CodeGen/CodeGen.cpp
@@ -54,6 +54,7 @@ void llvm::initializeCodeGen(PassRegistry &Registry) {
   initializeFinalizeISelPass(Registry);
   initializeFinalizeMachineBundlesPass(Registry);
   initializeFixupStatepointCallerSavedPass(Registry);
+  initializeFixStackmapsSpillReloadsPass(Registry);
   initializeFuncletLayoutPass(Registry);
   initializeGCMachineCodeAnalysisPass(Registry);
   initializeGCModuleInfoPass(Registry);

--- a/llvm/lib/CodeGen/TargetPassConfig.cpp
+++ b/llvm/lib/CodeGen/TargetPassConfig.cpp
@@ -56,6 +56,8 @@
 
 using namespace llvm;
 
+extern bool YkStackmapsSpillReloadsFix;
+
 static cl::opt<bool>
     EnableIPRA("enable-ipra", cl::init(false), cl::Hidden,
                cl::desc("Enable interprocedural register allocation "
@@ -1229,6 +1231,13 @@ void TargetPassConfig::addMachinePasses() {
 
   // Expand pseudo instructions before second scheduling pass.
   addPass(&ExpandPostRAPseudosID);
+
+  // Add pass to revert stackmap instructions altered by register allocation.
+  // We need to insert this pass late so that spill offsets will have been
+  // calculated.
+  if (YkStackmapsSpillReloadsFix) {
+    addPass(&FixStackmapsSpillReloadsID);
+  }
 
   // Run pre-sched2 passes.
   addPreSched2();

--- a/llvm/lib/CodeGen/Yk/FixStackmapsSpillReloads.cpp
+++ b/llvm/lib/CodeGen/Yk/FixStackmapsSpillReloads.cpp
@@ -1,0 +1,217 @@
+//===-- FixStackmapsSpillReloads.cpp - Fix spills before stackmaps --------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This pass fixes stackmaps in regards to spill reloads inserted by the
+// register allocator. For example, if we have the LLVM IR
+//
+//   call foo($10, $11)
+//   call llvm.experimental.stackmaps(1, 0, $8, $9)
+//
+// After register allocation we might get something like
+//
+//   movrr $rbx, $rsi
+//   movmr $rbp, -8, $rdi
+//   ...
+//   call foo($rsi, $rdi)
+//   movrr $rsi, $rbx
+//   movrm $rdi, $rbp, -8
+//   STACKMAP $rsi, $rdi
+//
+// In order to pass arguments to foo, the register allocator had to spill the
+// values in $rdi and $rsi into another register or onto the stack before the
+// call. Then immediately after the call it inserted instructions to reload
+// the spilled values back into the original registers. Since during
+// deoptimisation we return to immediately after the call, the stackmap is now
+// tracking the wrong values, e.g. in this case $rdi and $rsi instead of the
+// spill locations.
+//
+// This pass interates over all basic blocks, finds spill reloads inserted
+// inbetween a call and stackmap, replaces the stackmap operands with the
+// spill reloads, and then moves the stackmap instruction up just below the
+// call.
+//===----------------------------------------------------------------------===//
+
+#include "llvm/CodeGen/MachineBasicBlock.h"
+#include "llvm/CodeGen/MachineFrameInfo.h"
+#include "llvm/CodeGen/MachineFunction.h"
+#include "llvm/CodeGen/MachineFunctionPass.h"
+#include "llvm/CodeGen/MachineInstr.h"
+#include "llvm/CodeGen/MachineInstrBuilder.h"
+#include "llvm/CodeGen/MachineOperand.h"
+#include "llvm/CodeGen/Passes.h"
+#include "llvm/CodeGen/StackMaps.h"
+#include "llvm/CodeGen/TargetInstrInfo.h"
+#include "llvm/IR/DebugLoc.h"
+#include "llvm/InitializePasses.h"
+#include "llvm/Support/Debug.h"
+
+using namespace llvm;
+
+#define DEBUG_TYPE "fix-stackmaps-spill-reloads"
+
+namespace {
+
+class FixStackmapsSpillReloads : public MachineFunctionPass {
+public:
+  static char ID;
+
+  FixStackmapsSpillReloads() : MachineFunctionPass(ID) {
+    initializeFixStackmapsSpillReloadsPass(*PassRegistry::getPassRegistry());
+  }
+
+  void getAnalysisUsage(AnalysisUsage &AU) const override {
+    AU.setPreservesCFG();
+    MachineFunctionPass::getAnalysisUsage(AU);
+  }
+
+  StringRef getPassName() const override {
+    return "Stackmaps Fix Post RegAlloc Pass";
+  }
+
+  bool runOnMachineFunction(MachineFunction &MF) override;
+};
+
+} // namespace
+
+char FixStackmapsSpillReloads::ID = 0;
+char &llvm::FixStackmapsSpillReloadsID = FixStackmapsSpillReloads::ID;
+
+INITIALIZE_PASS_BEGIN(FixStackmapsSpillReloads, DEBUG_TYPE, "Fixup Stackmap Spills",
+                      false, false)
+INITIALIZE_PASS_END(FixStackmapsSpillReloads, DEBUG_TYPE, "Fixup Stackmap Spills",
+                    false, false)
+
+
+bool FixStackmapsSpillReloads::runOnMachineFunction(MachineFunction &MF) {
+  bool Changed = false;
+  const TargetInstrInfo *TII = MF.getSubtarget().getInstrInfo();
+  for (MachineBasicBlock &MBB : MF) {
+    bool Collect = false;
+    std::set<MachineInstr *> Erased;
+    MachineInstr *LastCall = nullptr;
+    std::map<Register, MachineInstr *> Spills;
+    for (MachineInstr &MI : MBB) {
+      if (MI.isCall() && !MI.isInlineAsm()) {
+        // YKFIXME: Do we need to check for intrinsics here or have they been
+        // removed during lowering?
+        if (MI.getOpcode() != TargetOpcode::STACKMAP &&
+            MI.getOpcode() != TargetOpcode::PATCHPOINT) {
+          // If we see a normal function call we know it will be followed by a
+          // STACKMAP instruction. Set `Collect` to `true` to collect all spill
+          // reload instructions between this call and the STACKMAP instruction.
+          // Also remember this call, so we can insert the new STACKMAP
+          // instruction right below it.
+          Collect = true;
+          LastCall = &MI;
+          Spills.clear();
+          continue;
+        }
+      }
+
+      if (MI.getOpcode() == TargetOpcode::STACKMAP) {
+        if (LastCall == nullptr) {
+          // There wasn't a call preceeding this stackmap, so this must be
+          // attached to a branch instruction.
+          continue;
+        }
+        Collect = false;
+        // Assemble a new stackmap instruction by copying over the operands of
+        // the old instruction to the new one, while replacing spilled operands
+        // as we go.
+        MachineInstr *NewMI =
+          MF.CreateMachineInstr(TII->get(TargetOpcode::STACKMAP), MI.getDebugLoc(), true);
+        MachineInstrBuilder MIB(MF, NewMI);
+        // Copy ID and shadow
+        auto *MOI = MI.operands_begin();
+        MIB.add(*MOI); // ID
+        MOI++;
+        MIB.add(*MOI); // Shadow
+        MOI++;
+        while (MOI != MI.operands_end()) {
+          if (MOI->isReg()) {
+            Register Reg = MOI->getReg();
+            // Check if the register operand in the stackmap is a restored
+            // spill.
+            if (Spills.count(Reg) > 0) {
+              // Get spill reload instruction
+              MachineInstr *SMI = Spills[Reg];
+              int FI;
+              if (TII->isCopyInstr(*SMI)) {
+                // If the reload is a simple copy, e.g. $rax = $rbx,
+                // just replace the stackmap operand with the source of the
+                // copy instruction.
+                MIB.add(SMI->getOperand(1));
+              } else if (TII->isLoadFromStackSlotPostFE(*SMI, FI)) {
+                // If the reload is a load from the stack, replace the operand
+                // with multiple operands describing a stack location.
+                MIB.addImm(StackMaps::IndirectMemRefOp);
+                std::optional<unsigned> Size = SMI->getRestoreSize(TII);
+                assert(Size.has_value() && "RestoreSize has no value.");
+                MIB.addImm(Size.value()); // Size
+                MIB.add(SMI->getOperand(1)); // Register
+                MIB.add(SMI->getOperand(4)); // Offset
+              } else {
+                assert(false && "Unknown instruction found");
+              }
+            } else {
+              MIB.add(*MOI);
+            }
+            MOI++;
+            continue;
+          }
+          // Copy all other operands over as is.
+          MIB.add(*MOI);
+          switch (MOI->getImm()) {
+            default:
+              llvm_unreachable("Unrecognized operand type.");
+            case StackMaps::DirectMemRefOp: {
+              MOI++;
+              MIB.add(*MOI); // Register
+              MOI++;
+              MIB.add(*MOI); // Offset
+              break;
+            }
+            case StackMaps::IndirectMemRefOp: {
+              MOI++;
+              MIB.add(*MOI); // Size
+              MOI++;
+              MIB.add(*MOI); // Register
+              MOI++;
+              MIB.add(*MOI); // Offset
+              break;
+            }
+            case StackMaps::ConstantOp: {break;}
+            case StackMaps::NextLive: {break;}
+          }
+          MOI++;
+        }
+        // Insert the new stackmap instruction just after the last call.
+        MI.getParent()->insertAfter(LastCall, NewMI);
+        // Remember the old stackmap instruction for deletion later.
+        Erased.insert(&MI);
+        LastCall = nullptr;
+        Changed = true;
+      }
+
+      // Collect spill reloads that appear between a call and its corresponding
+      // STACKMAP instruction.
+      if (Collect) {
+        int FI;
+        if (TII->isCopyInstr(MI) || TII->isLoadFromStackSlotPostFE(MI, FI)) {
+          Spills[MI.getOperand(0).getReg()] = &MI;
+        }
+      }
+    }
+    // Remove old stackmap instructions.
+    for (MachineInstr *E : Erased) {
+      E->eraseFromParent();
+    }
+  }
+
+  return Changed;
+}

--- a/llvm/lib/Support/Yk.cpp
+++ b/llvm/lib/Support/Yk.cpp
@@ -23,7 +23,8 @@ bool YkStackMapOffsetFix;
 static cl::opt<bool, true> YkStackMapOffsetFixParser(
     "yk-stackmap-offset-fix",
     cl::desc("Apply a fix to stackmaps that corrects the reported instruction "
-             "offset in the presence of calls."),
+             "offset in the presence of calls. (deprecated by "
+             "yk-stackmap-spillreloads-fix)"),
     cl::NotHidden, cl::location(YkStackMapOffsetFix));
 
 bool YkStackMapAdditionalLocs;
@@ -31,3 +32,10 @@ static cl::opt<bool, true> YkStackMapAdditionalLocsParser(
     "yk-stackmap-add-locs",
     cl::desc("Encode additional locations for registers into stackmaps."),
     cl::NotHidden, cl::location(YkStackMapAdditionalLocs));
+
+bool YkStackmapsSpillReloadsFix;
+static cl::opt<bool, true> YkStackMapSpillFixParser(
+    "yk-stackmap-spillreloads-fix",
+    cl::desc("Revert stackmaps and its operands after the register allocator "
+             "has emitted spill reloads."),
+    cl::NotHidden, cl::location(YkStackmapsSpillReloadsFix));

--- a/llvm/test/CodeGen/X86/yk-stackmaps-spillreloads-fix.ll
+++ b/llvm/test/CodeGen/X86/yk-stackmaps-spillreloads-fix.ll
@@ -1,0 +1,83 @@
+; RUN: llc -stop-after fix-stackmaps-spill-reloads --yk-stackmap-spillreloads-fix < %s  | FileCheck %s
+
+; CHECK-LABEL: name:            main
+; CHECK-LABEL: bb.0 (%ir-block.1):
+; CHECK-LABEL: CALL64pcrel32 target-flags(x86-plt) @foo2,
+; CHECK-NEXT: STACKMAP 1, 0, renamable $ebx, 3, renamable $r14d, 3, 1, 4, $rbp, -48, 3, renamable $r12d, 3, 1, 4, $rbp, -52, 3, renamable $r15d, 3, renamable $r13d, 3, implicit-def dead early-clobber $r11
+
+@.str = private unnamed_addr constant [13 x i8] c"%d %d %d %d\0A\00", align 1
+
+define dso_local i32 @foo(i32 noundef %0, i32 noundef %1, i32 noundef %2, i32 noundef %3, i32 noundef %4, i32 noundef %5, i32 noundef %6) #0 {
+  %8 = alloca i32, align 4
+  %9 = alloca i32, align 4
+  %10 = alloca i32, align 4
+  %11 = alloca i32, align 4
+  %12 = alloca i32, align 4
+  %13 = alloca i32, align 4
+  %14 = alloca i32, align 4
+  %15 = alloca i32, align 4
+  store i32 %0, ptr %9, align 4
+  store i32 %1, ptr %10, align 4
+  store i32 %2, ptr %11, align 4
+  store i32 %3, ptr %12, align 4
+  store i32 %4, ptr %13, align 4
+  store i32 %5, ptr %14, align 4
+  store i32 %6, ptr %15, align 4
+  %16 = load i32, ptr %9, align 4
+  %17 = load i32, ptr %10, align 4
+  %18 = load i32, ptr %11, align 4
+  %19 = load i32, ptr %12, align 4
+  %20 = load i32, ptr %13, align 4
+  %21 = load i32, ptr %14, align 4
+  %22 = load i32, ptr %15, align 4
+  %23 = call i32 (ptr, ...) @printf(ptr noundef @.str, i32 noundef %16, i32 noundef %17, i32 noundef %18, i32 noundef %19, i32 noundef %20, i32 noundef %21, i32 noundef %22)
+  %24 = load i32, ptr %8, align 4
+  ret i32 %24
+}
+
+declare i32 @printf(ptr noundef, ...) #2
+
+define dso_local i32 @main(i32 noundef %0) #0 {
+  %2 = alloca i32, align 4
+  %3 = alloca i32, align 4
+  %4 = alloca i32, align 4
+  %5 = alloca i32, align 4
+  %6 = alloca i32, align 4
+  %7 = alloca i32, align 4
+  %8 = alloca i32, align 4
+  %9 = alloca i32, align 4
+  store i32 %0, ptr %2, align 4
+  %10 = load i32, ptr %2, align 4
+  %11 = mul nsw i32 %10, 1
+  store i32 %11, ptr %3, align 4
+  %12 = load i32, ptr %2, align 4
+  %13 = mul nsw i32 %12, 2
+  store i32 %13, ptr %4, align 4
+  %14 = load i32, ptr %2, align 4
+  %15 = mul nsw i32 %14, 3
+  store i32 %15, ptr %5, align 4
+  %16 = load i32, ptr %2, align 4
+  %17 = mul nsw i32 %16, 4
+  store i32 %17, ptr %6, align 4
+  %18 = load i32, ptr %2, align 4
+  %19 = mul nsw i32 %18, 5
+  store i32 %19, ptr %7, align 4
+  %20 = load i32, ptr %2, align 4
+  %21 = mul nsw i32 %20, 6
+  store i32 %21, ptr %8, align 4
+  %22 = load i32, ptr %2, align 4
+  %23 = mul nsw i32 %22, 7
+  store i32 %23, ptr %9, align 4
+  %24 = call i32 @foo2(i32 noundef %23, i32 noundef %21, i32 noundef %19, i32 noundef %17, i32 noundef %15, i32 noundef %13, i32 noundef %11)
+  call void (i64, i32, ...) @llvm.experimental.stackmap(i64 1, i32 0, i32 %11, i32 %13, i32 %15, i32 %17, i32 %19, i32 %21, i32 %23)
+  %25 = mul nsw i32 %23, 5
+  %26 = call i32 (ptr, ...) @printf(ptr noundef @.str, i32 noundef %11, i32 noundef %13, i32 noundef %15, i32 noundef %17, i32 noundef %19, i32 noundef %21, i32 noundef %25)
+  ret i32 0
+}
+
+declare void @foo2(...)
+declare void @llvm.experimental.stackmap(i64, i32, ...)
+
+attributes #0 = { noinline nounwind optnone uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }


### PR DESCRIPTION
The register allocator may insert spills and spill reloads around function calls. Unfortunately, it doesn't take stackmap instructions into account, so spill reloads may be placed inbetween a call and the stackmap attached to it. This changes the offset of the stackmap and the variables it tracks, which is information we rely upon for deoptimisation.

This adds a new pass which "reverts" these changes, by moving the stackmap instruction back to right below the call, and updates its operand (i.e. tracked variables) as appropriate.