### PR TITLE
Add the yk-linkage llvm pass.

### DIFF
--- a/llvm/include/llvm/Transforms/Yk/Linkage.h
+++ b/llvm/include/llvm/Transforms/Yk/Linkage.h
@@ -1,0 +1,10 @@
+#ifndef LLVM_TRANSFORMS_YK_LINKAGE_H
+#define LLVM_TRANSFORMS_YK_LINKAGE_H
+
+#include "llvm/Pass.h"
+
+namespace llvm {
+ModulePass *createYkLinkagePass();
+} // namespace llvm
+
+#endif

--- a/llvm/lib/CodeGen/TargetPassConfig.cpp
+++ b/llvm/lib/CodeGen/TargetPassConfig.cpp
@@ -48,6 +48,7 @@
 #include "llvm/Transforms/Utils.h"
 #include "llvm/Transforms/Yk/BlockDisambiguate.h"
 #include "llvm/Transforms/Yk/ControlPoint.h"
+#include "llvm/Transforms/Yk/Linkage.h"
 #include "llvm/Transforms/Yk/ShadowStack.h"
 #include "llvm/Transforms/Yk/Stackmaps.h"
 #include <cassert>
@@ -262,6 +263,10 @@ static cl::opt<bool>
 static cl::opt<bool> YkPatchCtrlPoint("yk-patch-control-point", cl::init(false),
                                       cl::NotHidden,
                                       cl::desc("Patch yk_mt_control_point()"));
+
+static cl::opt<bool> YkLinkage("yk-linkage", cl::init(false),
+                                      cl::NotHidden,
+                                      cl::desc("Change functions with internal linkage to have external linkage"));
 
 static cl::opt<bool>
     YkShadowStack("yk-shadow-stack", cl::init(false), cl::NotHidden,
@@ -1128,6 +1133,10 @@ bool TargetPassConfig::addISelPasses() {
   // *not* being changed.
   if (YkPatchCtrlPoint) {
     addPass(createYkControlPointPass());
+  }
+
+  if (YkLinkage) {
+    addPass(createYkLinkagePass());
   }
 
   if (YkInsertStackMaps) {

--- a/llvm/lib/Transforms/Yk/CMakeLists.txt
+++ b/llvm/lib/Transforms/Yk/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_llvm_component_library(LLVMYkPasses
   BlockDisambiguate.cpp
   ControlPoint.cpp
+  Linkage.cpp
   LivenessAnalysis.cpp
   StackMaps.cpp
   ShadowStack.cpp

--- a/llvm/lib/Transforms/Yk/Linkage.cpp
+++ b/llvm/lib/Transforms/Yk/Linkage.cpp
@@ -1,0 +1,56 @@
+//===- Linkage.cpp - Ajdust linkage for the Yk JIT -----------------===//
+//
+// The JIT relies upon the use of `dlsym()` at runtime in order to lookup any
+// given function from its virtual address. For this to work the symbols for
+// all functions must be in the dynamic symbol table.
+//
+// `yk-config` already provides the `--export-dynamic` flag in order to ensure
+// that all *externally visible* symbols make it in to the dynamic symbol table,
+// but that's not enough: functions marked for internal linkage (e.g. `static`
+// functions in C) will be missed.
+//
+// This pass walks the functions of a module and flips any with internal linkage
+// to external linkage.
+//
+// Note that whilst symbols with internal linkage can have the same name and be
+// distinct, this is not so for symbols with external linkage. That's OK for
+// us because Yk requires the use of LTO, and the LTO module merger will have
+// already mangled the names for us so that symbol clashes can't occur.
+
+#include "llvm/Transforms/Yk/Linkage.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/Module.h"
+#include "llvm/InitializePasses.h"
+#include "llvm/Pass.h"
+
+#define DEBUG_TYPE "yk-linkage"
+
+using namespace llvm;
+
+namespace llvm {
+void initializeYkLinkagePass(PassRegistry &);
+} // namespace llvm
+
+namespace {
+class YkLinkage : public ModulePass {
+public:
+  static char ID;
+  YkLinkage() : ModulePass(ID) {
+    initializeYkLinkagePass(*PassRegistry::getPassRegistry());
+  }
+
+  bool runOnModule(Module &M) override {
+    for (Function &F : M) {
+      if (F.hasInternalLinkage()) {
+        F.setLinkage(GlobalVariable::ExternalLinkage);
+      }
+    }
+    return true;
+  }
+};
+} // namespace
+
+char YkLinkage::ID = 0;
+INITIALIZE_PASS(YkLinkage, DEBUG_TYPE, "yk-linkage", false, false)
+
+ModulePass *llvm::createYkLinkagePass() { return new YkLinkage(); }

--- a/llvm/test/Transforms/Yk/Linkage/YkLinkage.ll
+++ b/llvm/test/Transforms/Yk/Linkage/YkLinkage.ll
@@ -1,0 +1,10 @@
+; Checks that the yk-linkage pass changes functions to have external linkage.
+;
+; RUN: llc --yk-linkage -o - < %s | FileCheck %s
+; RUN: llc -o - < %s | FileCheck --check-prefix CHECK-NOPASS %s
+
+; CHECK: .globl myfunc
+; CHECK-NOPASS-NOT: .globl myfunc
+define internal void @myfunc() noinline {
+	ret void
+}


### PR DESCRIPTION
Compiler side fix for https://github.com/ykjit/yk/issues/647.

Depends on https://github.com/ykjit/yk/pull/650 and https://github.com/ykjit/ykllvm/pull/61.

See commit message for a detailed description of what this does.

Associated PRs for yk and yklua coming soon.

(I wanted to test the name mangling aspect of this, but the llvm test suite isn't geared up for multi-object tests. They defer such tests to another repo, which I don't really want to fork and maintain. We can rely on yk and interpreter tests)