### PR TITLE
Make new stackmaps in the form LLVM expects.

### DIFF
--- a/llvm/lib/CodeGen/Yk/FixStackmapsSpillReloads.cpp
+++ b/llvm/lib/CodeGen/Yk/FixStackmapsSpillReloads.cpp
@@ -190,6 +190,12 @@ bool FixStackmapsSpillReloads::runOnMachineFunction(MachineFunction &MF) {
           }
           MOI++;
         }
+        MachineOperand *Last = NewMI->operands_end() - 1;
+        if (!Last->isReg() || !Last->isImplicit()) {
+          // Unless the last operand is an implicit register, the last operand
+          // needs to be `NextLive` due to the way stackmaps are parsed.
+          MIB.addImm(StackMaps::NextLive);
+        }
         // Insert the new stackmap instruction just after the last call.
         MI.getParent()->insertAfter(LastCall, NewMI);
         // Remember the old stackmap instruction for deletion later.


### PR DESCRIPTION
LLVM's stackmap lowering pass expects a stackmap's operands to end with StackMaps::NextLive, unless the last operand is an implicit register. If we just happened to have updated the last operand with a spill reload we need make sure to add StackMaps::NextLive to the end.

This makes yklua build again.