### PR TITLE
Add the yk_promote function attribute.

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1458,6 +1458,13 @@ def MustTail : StmtAttr {
   let Subjects = SubjectList<[ReturnStmt], ErrorDiag, "return statements">;
 }
 
+def YkPromote : InheritableAttr {
+  let Spellings = [GCC<"yk_promote">, Declspec<"yk_promote">];
+  let Args = [VariadicStringArgument<"Vars">];
+  let Documentation = [YkPromoteDocs];
+  let Subjects = SubjectList<[Function], ErrorDiag, "functions">;
+}
+
 def FastCall : DeclOrTypeAttr {
   let Spellings = [GCC<"fastcall">, Keyword<"__fastcall">,
                    Keyword<"_fastcall">];

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -6826,6 +6826,19 @@ def YkUnrollSafeDocs : Documentation {
   }];
 }
 
+def YkPromoteDocs : Documentation {
+  let Category = DocCatFunction;
+  let Content = [{
+  The ``yk_promote`` attribute tells the Yk JIT which named function arguments
+  should be promoted to constants during trace compilation.
+
+  E.g.:
+  ``__attribute__((yk_promote("x")) void f(size_t x, size_t y) { ... }``
+
+  Only `size_t` (or equivalent) arguments may be promoted.
+  }];
+}
+
 def ReadOnlyPlacementDocs : Documentation {
   let Category = DocCatType;
   let Content = [{This attribute is attached to a structure, class or union declaration.

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -8122,6 +8122,23 @@ static void handleNoSanitizeAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
                                               Sanitizers.size()));
 }
 
+static void handleYkPromoteAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
+  std::vector<StringRef> Vars;
+
+  for (unsigned I = 0, E = AL.getNumArgs(); I != E; ++I) {
+    StringRef Name;
+    SourceLocation LiteralLoc;
+
+    if (!S.checkStringLiteralArgumentAttr(AL, I, Name, &LiteralLoc))
+      return;
+
+    Vars.push_back(Name);
+  }
+
+  D->addAttr(::new (S.Context)
+      YkPromoteAttr(S.Context, AL, Vars.data(), Vars.size()));
+}
+
 static void handleNoSanitizeSpecificAttr(Sema &S, Decl *D,
                                          const ParsedAttr &AL) {
   StringRef AttrName = AL.getAttrName()->getName();
@@ -9346,6 +9363,10 @@ ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D, const ParsedAttr &AL,
 
   case ParsedAttr::AT_UsingIfExists:
     handleSimpleAttribute<UsingIfExistsAttr>(S, D, AL);
+    break;
+
+  case ParsedAttr::AT_YkPromote:
+    handleYkPromoteAttr(S, D, AL);
     break;
   }
 }

--- a/clang/test/Misc/pragma-attribute-supported-attributes-list.test
+++ b/clang/test/Misc/pragma-attribute-supported-attributes-list.test
@@ -201,6 +201,7 @@
 // CHECK-NEXT: XRayInstrument (SubjectMatchRule_function, SubjectMatchRule_objc_method)
 // CHECK-NEXT: XRayLogArgs (SubjectMatchRule_function, SubjectMatchRule_objc_method)
 // CHECK-NEXT: YkOutline (SubjectMatchRule_function)
+// CHECK-NEXT: YkPromote (SubjectMatchRule_function)
 // CHECK-NEXT: YkUnrollSafe (SubjectMatchRule_function)
 // CHECK-NEXT: ZeroCallUsedRegs (SubjectMatchRule_function)
 // CHECK-NEXT: End of supported attributes.

--- a/clang/test/Yk/yk_promote.c
+++ b/clang/test/Yk/yk_promote.c
@@ -1,0 +1,15 @@
+// RUN: %clang -target x86_64-linux-gnu -c -emit-llvm %s -o - | llvm-dis -o - | FileCheck --check-prefix CHECK64 %s
+// RUN: %clang -target i386-pc-linux -c -emit-llvm %s -o - | llvm-dis -o - | FileCheck --check-prefix CHECK32 %s
+
+// Check that the C `yk_promote` function attribute becomes the LLVM `yk_promote`
+// function attribute.
+
+// Note that clang tests have to work without a libc at all, so we can't use
+// `size_t` in this function signature.
+__attribute__((noinline, yk_promote("x"))) void f(__SIZE_TYPE__ x) {}
+
+// CHECK64: define dso_local void @f(i64 noundef %x) #0 {
+// CHECK64: attributes #0 = {{{.*}}"yk_promote"="0"{{.*}}}
+
+// CHECK32: define dso_local void @f(i32 noundef %x) #0 {
+// CHECK32: attributes #0 = {{{.*}}"yk_promote"="0"{{.*}}}

--- a/clang/test/Yk/yk_promote_bogus_type.c
+++ b/clang/test/Yk/yk_promote_bogus_type.c
@@ -1,0 +1,7 @@
+// RUN: not %clang -c %s 2>&1 | FileCheck %s
+
+// Check that promoting an invalid variable name gives a decent error.
+
+__attribute__((yk_promote("x"))) void f(char x) {
+// CHECK: error: Invalid type (not size_t) for promoted variable: 'x'
+}

--- a/clang/test/Yk/yk_promote_bogus_varname.c
+++ b/clang/test/Yk/yk_promote_bogus_varname.c
@@ -1,0 +1,7 @@
+// RUN: not %clang -c %s 2>&1 | FileCheck %s
+
+// Check that promoting an invalid variable name gives a decent error.
+
+__attribute__((yk_promote("bogus"))) void f(int x, char *y) {
+// CHECK: error: Invalid promoted variable: 'bogus'
+}

--- a/clang/test/Yk/yk_promote_empty.c
+++ b/clang/test/Yk/yk_promote_empty.c
@@ -1,0 +1,5 @@
+// RUN: %clang -c %s
+
+// Check that an empty promote list is OK.
+
+__attribute__((yk_promote())) void f(void) { }

--- a/llvm/include/llvm/Transforms/Yk/PromoteRecorder.h
+++ b/llvm/include/llvm/Transforms/Yk/PromoteRecorder.h
@@ -1,0 +1,20 @@
+#ifndef LLVM_TRANSFORMS_YK_PROMOTE_RECORDER_H
+#define LLVM_TRANSFORMS_YK_PROMOTE_RECORDER_H
+
+#include "llvm/IR/PassManager.h"
+#include "llvm/Pass.h"
+
+namespace llvm {
+
+// The pass as a new-style pass.
+class YkPromoteRecorderPass : public PassInfoMixin<YkPromoteRecorderPass> {
+public:
+  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+};
+
+// Create the pass as an old-style pass.
+FunctionPass *createYkPromoteRecorderPass();
+
+} // namespace llvm
+
+#endif // LLVM_TRANSFORMS_YK_PROMOTE_RECORDER_H

--- a/llvm/lib/CodeGen/TargetPassConfig.cpp
+++ b/llvm/lib/CodeGen/TargetPassConfig.cpp
@@ -51,6 +51,7 @@
 #include "llvm/Transforms/Yk/Linkage.h"
 #include "llvm/Transforms/Yk/ShadowStack.h"
 #include "llvm/Transforms/Yk/Stackmaps.h"
+#include "llvm/Transforms/Yk/PromoteRecorder.h"
 #include <cassert>
 #include <optional>
 #include <string>
@@ -1136,6 +1137,10 @@ bool TargetPassConfig::addISelPasses() {
   if (YkPatchCtrlPoint) {
     addPass(createYkControlPointPass());
   }
+
+  // Note: the Yk promote recorder pass must run before the Yk stackmap pass.
+  // This ensures the promote recorder calls get stackmaps.
+  addPass(createYkPromoteRecorderPass());
 
   if (YkLinkage) {
     addPass(createYkLinkagePass());

--- a/llvm/lib/Passes/CMakeLists.txt
+++ b/llvm/lib/Passes/CMakeLists.txt
@@ -29,4 +29,5 @@ add_llvm_component_library(LLVMPasses
   TransformUtils
   Vectorize
   Instrumentation
+  YkPasses
   )

--- a/llvm/lib/Passes/PassBuilder.cpp
+++ b/llvm/lib/Passes/PassBuilder.cpp
@@ -255,6 +255,7 @@
 #include "llvm/Transforms/Vectorize/LoopVectorize.h"
 #include "llvm/Transforms/Vectorize/SLPVectorizer.h"
 #include "llvm/Transforms/Vectorize/VectorCombine.h"
+#include "llvm/Transforms/Yk/PromoteRecorder.h"
 #include <optional>
 
 using namespace llvm;

--- a/llvm/lib/Passes/PassRegistry.def
+++ b/llvm/lib/Passes/PassRegistry.def
@@ -403,6 +403,7 @@ FUNCTION_PASS("transform-warning", WarnMissedTransformationsPass())
 FUNCTION_PASS("tsan", ThreadSanitizerPass())
 FUNCTION_PASS("memprof", MemProfilerPass())
 FUNCTION_PASS("declare-to-assign", llvm::AssignmentTrackingPass())
+FUNCTION_PASS("yk-promote-recorder", YkPromoteRecorderPass())
 #undef FUNCTION_PASS
 
 #ifndef FUNCTION_PASS_WITH_PARAMS

--- a/llvm/lib/Transforms/Yk/CMakeLists.txt
+++ b/llvm/lib/Transforms/Yk/CMakeLists.txt
@@ -3,6 +3,7 @@ add_llvm_component_library(LLVMYkPasses
   ControlPoint.cpp
   Linkage.cpp
   LivenessAnalysis.cpp
+  PromoteRecorder.cpp
   StackMaps.cpp
   ShadowStack.cpp
 

--- a/llvm/lib/Transforms/Yk/PromoteRecorder.cpp
+++ b/llvm/lib/Transforms/Yk/PromoteRecorder.cpp
@@ -1,0 +1,168 @@
+//===- PromoteRecorder.cpp - Record value to be promtoed in a trace --===//
+//
+// This pass injects calls to a function which records the runtime values of
+// variables to be promoted during trace compilation.
+//
+// It recognises call-sites of functions annotated with `yk_promote`, recording
+// the values of the specified arguments prior to the call.
+
+#include <iostream>
+#include <sstream>
+
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/PassManager.h"
+#include "llvm/IR/Verifier.h"
+#include "llvm/InitializePasses.h"
+#include "llvm/Pass.h"
+#include "llvm/Transforms/Yk/PromoteRecorder.h"
+
+#define DEBUG_TYPE "yk-promote-recorder"
+
+using namespace llvm;
+
+const std::string RecordFnName = "__yk_record_promote_usize";
+
+namespace llvm {
+void initializeYkPromoteRecorderPass(PassRegistry &);
+} // namespace llvm
+
+namespace {
+
+// Shared innards of both the old-style and new-style pass.
+bool impl(Function &F) {
+  LLVMContext &Context = F.getContext();
+
+  // We do this in two stages to avoid iterator invalidation.
+  //
+  // First just find where we will need to inject calls to the promote
+  // recorder.
+  std::vector<CallInst *> CallsToPromoted;
+  for (BasicBlock &BB : F) {
+    for (Instruction &I : BB) {
+      if (CallInst *CI = dyn_cast<CallInst>(&I)) {
+        Function *CF = CI->getCalledFunction();
+        if (CF && !CF->isDeclaration() && CF->hasFnAttribute("yk_promote")) {
+          CallsToPromoted.push_back(CI);
+        }
+      }
+    }
+  }
+
+  if (CallsToPromoted.empty()) {
+    return false;
+  }
+
+  // Ensure there is a declaration for the recorder function.
+  Module *M = F.getParent();
+  Function *Recorder = M->getFunction(RecordFnName);
+  DataLayout DL(M);
+  if (!Recorder) {
+    // args: char *funcname, size_t num_pairs, ...
+    // where ... is (arg_idx, val) pairs
+    FunctionType *RFT = FunctionType::get(
+        Type::getVoidTy(Context),
+        {PointerType::get(Context, 0), DL.getIntPtrType(Context)}, true);
+    Recorder = Function::Create(RFT, GlobalValue::LinkageTypes::ExternalLinkage,
+                                RecordFnName, M);
+  }
+
+  // Now inject calls to the recorder.
+  for (CallInst *CI : CallsToPromoted) {
+    // Get the comma separated values and parse them.
+    // Do this first, so we know how many of them there are ahead of time.
+    Function *CF = CI->getCalledFunction();
+    std::string AttrVal =
+        CF->getFnAttribute("yk_promote").getValueAsString().data();
+    std::istringstream SS(AttrVal);
+    std::string ArgStr;
+    std::vector<size_t> PromoteIdxs;
+    while (std::getline(SS, ArgStr, ',')) {
+      std::stringstream CSS(ArgStr);
+      size_t PromoteIdx;
+      CSS >> PromoteIdx; // converts string to size_t.
+      PromoteIdxs.push_back(PromoteIdx);
+    }
+
+    std::vector<Value *> RecorderArgs;
+
+    // First arg: function name whose arg is being promoted. i.e. callee.
+    //
+    // YKOPT: strings get duplicated if there are many calls to the same
+    // function with promoted arguments.
+    llvm::Constant *InternFuncName =
+        llvm::ConstantDataArray::getString(Context, CF->getName());
+    llvm::GlobalVariable *InternFuncNameGV = new llvm::GlobalVariable(
+        *M, InternFuncName->getType(), true,
+        llvm::GlobalVariable::LinkageTypes::ExternalLinkage, InternFuncName,
+        "promote_fname");
+    RecorderArgs.push_back(InternFuncNameGV);
+
+    // Second arg: number of promoted arguments.
+    IRBuilder Builder(CI);
+    llvm::ConstantInt *NumPromotes =
+        Builder.getIntN(DL.getPointerSize() * 8, PromoteIdxs.size());
+    RecorderArgs.push_back(NumPromotes);
+
+    // Remaining varargs arguments: (arg-idx, val) pairs.
+    for (size_t Idx : PromoteIdxs) {
+      // Note: the language front-end is expected to have checked the promoted
+      // variable indices are in-range and of the right type.
+      assert(Idx <= CI->arg_size() - 1);
+      Value *PVal = CI->getArgOperand(Idx);
+      assert(isa<IntegerType>(PVal->getType()));
+      assert(cast<IntegerType>(PVal->getType())->getBitWidth() ==
+             DL.getPointerSize() * 8);
+      RecorderArgs.push_back(Builder.getIntN(DL.getPointerSize() * 8, Idx));
+      RecorderArgs.push_back(PVal);
+    }
+
+    // And finally, emit the call to the recorder function.
+    //
+    // Note that `YkStackmapsPass` will run after this pass, adding a stackmap
+    // for this call, so we don't have to do it ourselves here.
+    Builder.CreateCall(Recorder, RecorderArgs);
+  }
+
+  // Our pass runs after LLVM normally does its verify pass. In debug builds
+  // we run it again to check that our pass is generating valid IR.
+  if (verifyModule(*M, &errs())) {
+    Context.emitError("Yk promote recorder pass generated invalid IR!");
+    return false;
+  }
+
+  return true;
+}
+} // namespace
+
+// The new-style pass.
+PreservedAnalyses YkPromoteRecorderPass::run(Function &F,
+                                             FunctionAnalysisManager &AM) {
+  if (impl(F)) {
+    return PreservedAnalyses::none();
+  }
+  return PreservedAnalyses::all();
+}
+
+namespace {
+// The old-style pass.
+class YkPromoteRecorder : public FunctionPass {
+public:
+  static char ID;
+
+  YkPromoteRecorder() : FunctionPass(ID) {
+    initializeYkPromoteRecorderPass(*PassRegistry::getPassRegistry());
+  }
+
+  bool runOnFunction(Function &F) override { return impl(F); }
+};
+} // namespace
+
+char YkPromoteRecorder::ID = 0;
+INITIALIZE_PASS(YkPromoteRecorder, DEBUG_TYPE, "Yk Promote Recorder", false,
+                false)
+
+FunctionPass *llvm::createYkPromoteRecorderPass() {
+  return new YkPromoteRecorder();
+}

--- a/llvm/test/CodeGen/AArch64/O0-pipeline.ll
+++ b/llvm/test/CodeGen/AArch64/O0-pipeline.ll
@@ -29,6 +29,7 @@
 ; CHECK-NEXT:       AArch64 Stack Tagging
 ; CHECK-NEXT:       SME ABI Pass
 ; CHECK-NEXT:       Exception handling preparation
+; CHECK-NEXT:       Yk Promote Recorder
 ; CHECK-NEXT:       Safe Stack instrumentation pass
 ; CHECK-NEXT:       Insert stack protectors
 ; CHECK-NEXT:       Module Verifier

--- a/llvm/test/CodeGen/AArch64/O3-pipeline.ll
+++ b/llvm/test/CodeGen/AArch64/O3-pipeline.ll
@@ -94,6 +94,7 @@
 ; CHECK-NEXT:       CodeGen Prepare
 ; CHECK-NEXT:       Dominator Tree Construction
 ; CHECK-NEXT:       Exception handling preparation
+; CHECK-NEXT:       Yk Promote Recorder
 ; CHECK-NEXT:     AArch64 Promote Constant
 ; CHECK-NEXT:       FunctionPass Manager
 ; CHECK-NEXT:         Dominator Tree Construction

--- a/llvm/test/CodeGen/AMDGPU/llc-pipeline.ll
+++ b/llvm/test/CodeGen/AMDGPU/llc-pipeline.ll
@@ -62,6 +62,7 @@
 ; GCN-O0-NEXT:        Lower SwitchInst's to branches
 ; GCN-O0-NEXT:        Lower invoke and unwind, for unwindless code generators
 ; GCN-O0-NEXT:        Remove unreachable blocks from the CFG
+; GCN-O0-NEXT:        Yk Promote Recorder
 ; GCN-O0-NEXT:        Post-Dominator Tree Construction
 ; GCN-O0-NEXT:        Dominator Tree Construction
 ; GCN-O0-NEXT:        Natural Loop Information
@@ -245,6 +246,7 @@
 ; GCN-O1-NEXT:        Lower SwitchInst's to branches
 ; GCN-O1-NEXT:        Lower invoke and unwind, for unwindless code generators
 ; GCN-O1-NEXT:        Remove unreachable blocks from the CFG
+; GCN-O1-NEXT:        Yk Promote Recorder
 ; GCN-O1-NEXT:        Dominator Tree Construction
 ; GCN-O1-NEXT:        Basic Alias Analysis (stateless AA impl)
 ; GCN-O1-NEXT:        Function Alias Analysis Results
@@ -541,6 +543,7 @@
 ; GCN-O1-OPTS-NEXT:        Lower SwitchInst's to branches
 ; GCN-O1-OPTS-NEXT:        Lower invoke and unwind, for unwindless code generators
 ; GCN-O1-OPTS-NEXT:        Remove unreachable blocks from the CFG
+; GCN-O1-OPTS-NEXT:        Yk Promote Recorder
 ; GCN-O1-OPTS-NEXT:        Dominator Tree Construction
 ; GCN-O1-OPTS-NEXT:        Basic Alias Analysis (stateless AA impl)
 ; GCN-O1-OPTS-NEXT:        Function Alias Analysis Results
@@ -845,6 +848,7 @@
 ; GCN-O2-NEXT:        Lower SwitchInst's to branches
 ; GCN-O2-NEXT:        Lower invoke and unwind, for unwindless code generators
 ; GCN-O2-NEXT:        Remove unreachable blocks from the CFG
+; GCN-O2-NEXT:        Yk Promote Recorder
 ; GCN-O2-NEXT:        Dominator Tree Construction
 ; GCN-O2-NEXT:        Basic Alias Analysis (stateless AA impl)
 ; GCN-O2-NEXT:        Function Alias Analysis Results
@@ -1162,6 +1166,7 @@
 ; GCN-O3-NEXT:        Lower SwitchInst's to branches
 ; GCN-O3-NEXT:        Lower invoke and unwind, for unwindless code generators
 ; GCN-O3-NEXT:        Remove unreachable blocks from the CFG
+; GCN-O3-NEXT:        Yk Promote Recorder
 ; GCN-O3-NEXT:        Dominator Tree Construction
 ; GCN-O3-NEXT:        Basic Alias Analysis (stateless AA impl)
 ; GCN-O3-NEXT:        Function Alias Analysis Results

--- a/llvm/test/CodeGen/ARM/O3-pipeline.ll
+++ b/llvm/test/CodeGen/ARM/O3-pipeline.ll
@@ -54,7 +54,9 @@
 ; CHECK-NEXT:      CodeGen Prepare
 ; CHECK-NEXT:      Dominator Tree Construction
 ; CHECK-NEXT:      Exception handling preparation
+; CHECK-NEXT:      Yk Promote Recorder
 ; CHECK-NEXT:      Merge internal globals
+; CHECK-NEXT:      Dominator Tree Construction
 ; CHECK-NEXT:      Natural Loop Information
 ; CHECK-NEXT:      Scalar Evolution Analysis
 ; CHECK-NEXT:      Lazy Branch Probability Analysis

--- a/llvm/test/CodeGen/LoongArch/O0-pipeline.ll
+++ b/llvm/test/CodeGen/LoongArch/O0-pipeline.ll
@@ -31,6 +31,7 @@
 ; CHECK-NEXT:       Scalarize Masked Memory Intrinsics
 ; CHECK-NEXT:       Expand reduction intrinsics
 ; CHECK-NEXT:       Exception handling preparation
+; CHECK-NEXT:       Yk Promote Recorder
 ; CHECK-NEXT:       Safe Stack instrumentation pass
 ; CHECK-NEXT:       Insert stack protectors
 ; CHECK-NEXT:       Module Verifier

--- a/llvm/test/CodeGen/LoongArch/opt-pipeline.ll
+++ b/llvm/test/CodeGen/LoongArch/opt-pipeline.ll
@@ -70,9 +70,11 @@
 ; CHECK-NEXT:       CodeGen Prepare
 ; CHECK-NEXT:       Dominator Tree Construction
 ; CHECK-NEXT:       Exception handling preparation
+; CHECK-NEXT:       Yk Promote Recorder
 ; CHECK-NEXT:       Safe Stack instrumentation pass
 ; CHECK-NEXT:       Insert stack protectors
 ; CHECK-NEXT:       Module Verifier
+; CHECK-NEXT:       Dominator Tree Construction
 ; CHECK-NEXT:       Basic Alias Analysis (stateless AA impl)
 ; CHECK-NEXT:       Function Alias Analysis Results
 ; CHECK-NEXT:       Natural Loop Information

--- a/llvm/test/CodeGen/PowerPC/O0-pipeline.ll
+++ b/llvm/test/CodeGen/PowerPC/O0-pipeline.ll
@@ -30,6 +30,7 @@
 ; CHECK-NEXT:       Scalarize Masked Memory Intrinsics
 ; CHECK-NEXT:       Expand reduction intrinsics
 ; CHECK-NEXT:       Exception handling preparation
+; CHECK-NEXT:       Yk Promote Recorder
 ; CHECK-NEXT:       Safe Stack instrumentation pass
 ; CHECK-NEXT:       Insert stack protectors
 ; CHECK-NEXT:       Module Verifier

--- a/llvm/test/CodeGen/PowerPC/O3-pipeline.ll
+++ b/llvm/test/CodeGen/PowerPC/O3-pipeline.ll
@@ -72,6 +72,8 @@
 ; CHECK-NEXT:       CodeGen Prepare
 ; CHECK-NEXT:       Dominator Tree Construction
 ; CHECK-NEXT:       Exception handling preparation
+; CHECK-NEXT:       Yk Promote Recorder
+; CHECK-NEXT:       Dominator Tree Construction
 ; CHECK-NEXT:       Natural Loop Information
 ; CHECK-NEXT:       Scalar Evolution Analysis
 ; CHECK-NEXT:       Prepare loop for ppc preferred instruction forms

--- a/llvm/test/CodeGen/RISCV/O0-pipeline.ll
+++ b/llvm/test/CodeGen/RISCV/O0-pipeline.ll
@@ -31,6 +31,7 @@
 ; CHECK-NEXT:       Scalarize Masked Memory Intrinsics
 ; CHECK-NEXT:       Expand reduction intrinsics
 ; CHECK-NEXT:       Exception handling preparation
+; CHECK-NEXT:       Yk Promote Recorder
 ; CHECK-NEXT:       Safe Stack instrumentation pass
 ; CHECK-NEXT:       Insert stack protectors
 ; CHECK-NEXT:       Module Verifier

--- a/llvm/test/CodeGen/RISCV/O3-pipeline.ll
+++ b/llvm/test/CodeGen/RISCV/O3-pipeline.ll
@@ -64,6 +64,7 @@
 ; CHECK-NEXT:       CodeGen Prepare
 ; CHECK-NEXT:       Dominator Tree Construction
 ; CHECK-NEXT:       Exception handling preparation
+; CHECK-NEXT:       Yk Promote Recorder
 ; CHECK-NEXT:     A No-Op Barrier Pass
 ; CHECK-NEXT:     FunctionPass Manager
 ; CHECK-NEXT:       Safe Stack instrumentation pass

--- a/llvm/test/CodeGen/X86/O0-pipeline.ll
+++ b/llvm/test/CodeGen/X86/O0-pipeline.ll
@@ -32,6 +32,7 @@
 ; CHECK-NEXT:       Expand reduction intrinsics
 ; CHECK-NEXT:       Expand indirectbr instructions
 ; CHECK-NEXT:       Exception handling preparation
+; CHECK-NEXT:       Yk Promote Recorder
 ; CHECK-NEXT:       Safe Stack instrumentation pass
 ; CHECK-NEXT:       Insert stack protectors
 ; CHECK-NEXT:       Module Verifier

--- a/llvm/test/CodeGen/X86/opt-pipeline.ll
+++ b/llvm/test/CodeGen/X86/opt-pipeline.ll
@@ -72,9 +72,11 @@
 ; CHECK-NEXT:       CodeGen Prepare
 ; CHECK-NEXT:       Dominator Tree Construction
 ; CHECK-NEXT:       Exception handling preparation
+; CHECK-NEXT:       Yk Promote Recorder
 ; CHECK-NEXT:       Safe Stack instrumentation pass
 ; CHECK-NEXT:       Insert stack protectors
 ; CHECK-NEXT:       Module Verifier
+; CHECK-NEXT:       Dominator Tree Construction
 ; CHECK-NEXT:       Basic Alias Analysis (stateless AA impl)
 ; CHECK-NEXT:       Function Alias Analysis Results
 ; CHECK-NEXT:       Natural Loop Information

--- a/llvm/test/Transforms/Yk/PromoteRecorder/promote_many_funcs.ll
+++ b/llvm/test/Transforms/Yk/PromoteRecorder/promote_many_funcs.ll
@@ -1,0 +1,30 @@
+; RUN: opt < %s -passes=yk-promote-recorder -S | FileCheck %s
+
+target triple = "x86_64-unknown-linux-gnu"
+
+define dso_local void @f(i64 noundef %w, i64 noundef %x, i64 noundef %y, i64 noundef %z) #0 {
+entry:
+    ret void
+}
+attributes #0 = { "yk_promote"="0,2,3" "noinline" }
+
+define dso_local void @g(i64 noundef %w, i64 noundef %x, i64 noundef %y, i64 noundef %z) #1 {
+entry:
+; CHECK: call void (ptr, i64, ...) @__yk_record_promote_usize(ptr @promote_fname, i64 3, i64 0, i64 %z, i64 2, i64 %z, i64 3, i64 %z)
+    call void @f(i64 %z, i64 %z, i64 %z, i64 %z)
+    ret void
+}
+attributes #1 = { "yk_promote"="0,1" "noinline" }
+
+define dso_local i32 @main(i32 noundef %argc, ptr noundef %argv) {
+entry:
+    %a = sext i32 %argc to i64
+    %b = add i64 %a, 1
+    %c = add i64 %a, 2
+    %d = add i64 %a, 3
+; CHECK: call void (ptr, i64, ...) @__yk_record_promote_usize(ptr @promote_fname.1, i64 3, i64 0, i64 %a, i64 2, i64 %c, i64 3, i64 %d)
+    call void @f(i64 noundef %a, i64 noundef %b, i64 noundef %c, i64 noundef %d)
+; CHECK: call void (ptr, i64, ...) @__yk_record_promote_usize(ptr @promote_fname.2, i64 2, i64 0, i64 %d, i64 1, i64 %c)
+    call void @g(i64 noundef %d, i64 noundef %c, i64 noundef %b, i64 noundef %a)
+    ret i32 0
+}

--- a/llvm/test/Transforms/Yk/PromoteRecorder/promote_many_vars.ll
+++ b/llvm/test/Transforms/Yk/PromoteRecorder/promote_many_vars.ll
@@ -1,0 +1,20 @@
+; RUN: opt < %s -passes=yk-promote-recorder -S | FileCheck %s
+
+target triple = "x86_64-unknown-linux-gnu"
+
+define dso_local void @f(i64 noundef %w, i64 noundef %x, i64 noundef %y, i64 noundef %z) #0 {
+entry:
+    ret void
+}
+attributes #0 = { "yk_promote"="0,2,3" "noinline" }
+
+define dso_local i32 @main(i32 noundef %argc, ptr noundef %argv) {
+entry:
+    %a = sext i32 %argc to i64
+    %b = add i64 %a, 1
+    %c = add i64 %a, 2
+    %d = add i64 %a, 3
+; CHECK: call void (ptr, i64, ...) @__yk_record_promote_usize(ptr @promote_fname, i64 3, i64 0, i64 %a, i64 2, i64 %c, i64 3, i64 %d)
+    call void @f(i64 noundef %a, i64 noundef %b, i64 noundef %c, i64 noundef %d)
+    ret i32 0
+}

--- a/llvm/test/Transforms/Yk/PromoteRecorder/promote_single.ll
+++ b/llvm/test/Transforms/Yk/PromoteRecorder/promote_single.ll
@@ -1,0 +1,17 @@
+; RUN: opt < %s -passes=yk-promote-recorder -S | FileCheck %s
+
+target triple = "x86_64-unknown-linux-gnu"
+
+define dso_local void @f(i64 noundef %x) #0 {
+entry:
+    ret void
+}
+attributes #0 = { "yk_promote"="0" }
+
+define dso_local i32 @main(i32 noundef %argc, ptr noundef %argv) {
+entry:
+    %conv = sext i32 %argc to i64
+; CHECK: call void (ptr, i64, ...) @__yk_record_promote_usize(ptr @promote_fname, i64 1, i64 0, i64 %conv)
+    call void @f(i64 noundef %conv)
+    ret i32 0
+}


### PR DESCRIPTION
This attribute tells the trace compiler which function arguments should be promoted to constants during trace compilation.

Example:

```
__attribute__((yk_promote("x", "y")))
void f(size_t x, size_t y, size_t z) {
  ...
}
```

This works by injecting calls to a recorder function at the callsites of functions annotated in this fashion. At trace-compile-time, the JIT fishes the recorded constants back out.

Only size_t-typed arguments can be promoted for now.