### PR TITLE
Fix bug in FixStackmapsSpillReloads pass.

### DIFF
--- a/llvm/lib/CodeGen/Yk/FixStackmapsSpillReloads.cpp
+++ b/llvm/lib/CodeGen/Yk/FixStackmapsSpillReloads.cpp
@@ -137,7 +137,11 @@ bool FixStackmapsSpillReloads::runOnMachineFunction(MachineFunction &MF) {
             Register Reg = MOI->getReg();
             // Check if the register operand in the stackmap is a restored
             // spill.
-            if (Spills.count(Reg) > 0) {
+            // Since implicit operands are ignored by stackmaps (they are not
+            // added into the record) we must not replace them with spills so
+            // we don't add extra locations that aren't needed. Doing so leads
+            // to bugs during deoptimisation.
+            if (Spills.count(Reg) > 0 && !MOI->isImplicit()) {
               // Get spill reload instruction
               MachineInstr *SMI = Spills[Reg];
               int FI;


### PR DESCRIPTION
This PR fixes a bug inside our pass that fixes stackmap calls at the machine IR level after the register allocator has inserted spill reloads. See a4b6b9fd743639cb7d3432477206ad6edd5d1c5c for more details.

So far the only place I've seen this bug is inside yklua running `db.lua` (or `events.lua`?). I have failed to create a test that reproduces the bug outside of yklua.

Before merging this we might want to wait for @nmdis1999 to finish experimenting with running `creduce` to hopefully tickle a small enough test case out of `yklua`.

@nmdis1999 You can use the following diff to make `yklua` fail to compile when a problematic stackmap is generated. That should allow `creduce` to do its thing.

```diff
diff --git a/llvm/lib/CodeGen/Yk/FixStackmapsSpillReloads.cpp b/llvm/lib/CodeGen/Yk/FixStackmapsSpillReloads.cpp
index 42b3a8be4ab7..6d5db9663637 100644
--- a/llvm/lib/CodeGen/Yk/FixStackmapsSpillReloads.cpp
+++ b/llvm/lib/CodeGen/Yk/FixStackmapsSpillReloads.cpp
@@ -138,6 +138,7 @@ bool FixStackmapsSpillReloads::runOnMachineFunction(MachineFunction &MF) {
             // Check if the register operand in the stackmap is a restored
             // spill.
             if (Spills.count(Reg) > 0) {
+              assert(!MOI->isImplicit());
               // Get spill reload instruction
               MachineInstr *SMI = Spills[Reg];
               int FI;
```