### PR TITLE
Set shadowstack to be thread local global variable.

### DIFF
--- a/llvm/lib/Transforms/Yk/ShadowStack.cpp
+++ b/llvm/lib/Transforms/Yk/ShadowStack.cpp
@@ -75,6 +75,7 @@ public:
     // allocated for the shadow stack.
     Constant *GShadowStackPtr = M.getOrInsertGlobal(G_SHADOW_STACK, Int8PtrTy);
     GlobalVariable *GVar = M.getNamedGlobal(G_SHADOW_STACK);
+    GVar->setThreadLocal(true);
     GVar->setInitializer(
         ConstantPointerNull::get(cast<PointerType>(Int8PtrTy)));
 


### PR DESCRIPTION
Related: 
https://github.com/ykjit/yk/issues/784

Thread-local stack is essential to avoid race conditions where threads share the same global state.