### PR TITLE
No need to run `buildO0defaultPipeline` manually.

### DIFF
--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -1027,7 +1027,6 @@ void EmitAssemblyHelper::RunOptimizationPipeline(
     }
 
     if (!NewPMPasses.empty()) {
-      MPM.addPass(PB.buildO0DefaultPipeline(Level, PrepareForThinLTO || PrepareForLTO));
       if (auto Err = PB.parsePassPipeline(MPM, NewPMPasses)) {
         report_fatal_error(Twine("unable to parse pass pipeline description '") +
             NewPMPasses + "': " + toString(std::move(Err)));


### PR DESCRIPTION
The call to `PB.parsePassPipeline` will make sure the default pipeline is run. This is now equivalent to how custom pipelines are ran in `LTOBackend`.