### PR TITLE
Don't conflate a call with an unknown target with an indirect call.

### DIFF
--- a/llvm/include/llvm/CodeGen/AsmPrinter.h
+++ b/llvm/include/llvm/CodeGen/AsmPrinter.h
@@ -254,10 +254,10 @@ private:
   ///  - A symbol marking the call instruction.
   ///  - A symbol marking the return address of the call (if it were to return
   ///    by conventional means)
-  ///  - If it's a direct call, a symbol marking the target of the call, or
-  ///    `nullptr` if the call is indirect.
+  ///  - A symbol marking the target of the call, if known.
+  ///  - A boolean indicating if it's a direct call (true) or not (false).
   std::map<const MachineBasicBlock *,
-           SmallVector<std::tuple<MCSymbol *, MCSymbol *, MCSymbol *>>>
+           SmallVector<std::tuple<MCSymbol *, MCSymbol *, MCSymbol *, bool>>>
       YkCallMarkerSyms;
 
 protected:

--- a/llvm/test/CodeGen/X86/yk-basic-block-sections.ll
+++ b/llvm/test/CodeGen/X86/yk-basic-block-sections.ll
@@ -1,0 +1,51 @@
+; RUN: llc < %s -mtriple=x86_64 -function-sections -basic-block-sections=labels -yk-extended-llvmbbaddrmap-section -emulated-tls | FileCheck %s
+
+@G = thread_local global i32 0
+
+declare void @foo(ptr)
+
+define void @bar() noinline {
+  ret void
+}
+
+declare void @baz()
+
+define dso_local void @the_func(ptr %0) {
+  ; Note that the emulated TLS access will make an extra direct call with an
+  ; unknown target.
+  call void @foo(ptr @G)
+  call void @bar()
+  call void %0()
+  ret void
+}
+
+; CHECK:		.section .llvm_bb_addr_map,"o",@llvm_bb_addr_map,.text.the_func{{$}}
+; CHECK-NEXT:		.byte 2			    # version
+; CHECK-NEXT:		.byte 0			    # feature
+; CHECK-NEXT:		.quad .Lfunc_begin1 # function address
+; CHECK-NEXT:	    .byte 1             # number of basic blocks
+; CHECK-NEXT:		.byte 0             # BB id
+; CHECK-NEXT:		.uleb128 .Lfunc_begin1-.Lfunc_begin1
+; CHECK-NEXT:       .uleb128 .LBB_END1_0-.Lfunc_begin1
+; CHECK-NEXT:		.byte 1
+; CHECK-NEXT:		.byte 1               # num corresponding blocks
+; CHECK-NEXT:		.byte 0               # corresponding block
+; CHECK-NEXT:		.byte 4               # num calls
+; CHECK-NEXT:		.quad .Lyk_precall0   # call offset
+; CHECK-NEXT:		.quad .Lyk_postcall0  # return offset
+; CHECK-NEXT:		.quad 0               # target offset
+; CHECK-NEXT:		.byte 1               # direct?
+; CHECK-NEXT:		.quad .Lyk_precall1   # call offset
+; CHECK-NEXT:		.quad .Lyk_postcall1  # return offset
+; CHECK-NEXT:		.quad foo             # target offset
+; CHECK-NEXT:		.byte 1               # direct?
+; CHECK-NEXT:		.quad .Lyk_precall2   # call offset
+; CHECK-NEXT:		.quad .Lyk_postcall2  # return offset
+; CHECK-NEXT:		.quad bar             # target offset
+; CHECK-NEXT:		.byte 1               # direct?
+; CHECK-NEXT:		.quad .Lyk_precall3   # call offset
+; CHECK-NEXT:		.quad .Lyk_postcall3  # return offset
+; CHECK-NEXT:		.quad 0               # target offset
+; CHECK-NEXT:		.byte 0               # direct?
+
+; FIXME: test our other extensions to the blockmap.


### PR DESCRIPTION
You can call an external symbol (with an address statically unknown) directly.

Required by https://github.com/ykjit/yk/pull/916