### PR TITLE
Don't SHF_ALLOC the blockmap and LLVM bitcode sections.

### DIFF
--- a/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
+++ b/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
@@ -71,8 +71,6 @@
 using namespace llvm;
 using namespace dwarf;
 
-extern bool YkAllocLLVMBCSection;
-
 static cl::opt<bool> JumpTableInFunctionSection(
     "jumptable-in-function-section", cl::Hidden, cl::init(false),
     cl::desc("Putting Jump Table in function section"));
@@ -810,12 +808,6 @@ static MCSection *selectExplicitSectionGlobal(
       Retain, ForceUnique);
 
   const MCSymbolELF *LinkedToSym = getLinkedToSymbol(GO, TM);
-
-  // The Yk JIT expects to load the IR from its address space. This tells the
-  // loader to load the section.
-  if (YkAllocLLVMBCSection && (SectionName == ".llvmbc"))
-    Flags |= llvm::ELF::SHF_ALLOC;
-
   MCSectionELF *Section = Ctx.getELFSection(
       SectionName, getELFSectionType(SectionName, Kind), Flags, EntrySize,
       Group, IsComdat, UniqueID, LinkedToSym);

--- a/llvm/lib/MC/MCObjectFileInfo.cpp
+++ b/llvm/lib/MC/MCObjectFileInfo.cpp
@@ -1131,8 +1131,6 @@ MCObjectFileInfo::getStackSizesSection(const MCSection &TextSec) const {
                             cast<MCSymbolELF>(TextSec.getBeginSymbol()));
 }
 
-extern bool YkAllocLLVMBBAddrMapSection;
-
 MCSection *
 MCObjectFileInfo::getBBAddrMapSection(const MCSection &TextSec) const {
   if (Ctx->getObjectFileType() != MCContext::IsELF)
@@ -1145,9 +1143,6 @@ MCObjectFileInfo::getBBAddrMapSection(const MCSection &TextSec) const {
     GroupName = Group->getName();
     Flags |= ELF::SHF_GROUP;
   }
-
-  if (YkAllocLLVMBBAddrMapSection)
-    Flags |= ELF::SHF_ALLOC;
 
   // Use the text section's begin symbol and unique ID to create a separate
   // .llvm_bb_addr_map section associated with every unique text section.

--- a/llvm/lib/Support/Yk.cpp
+++ b/llvm/lib/Support/Yk.cpp
@@ -4,35 +4,6 @@
 
 using namespace llvm;
 
-bool YkAllocLLVMBCSection;
-namespace {
-struct CreateYkAllocLLVMBCSectionParser {
-  static void *call() {
-    return new cl::opt<bool, true>(
-        "yk-alloc-llvmbc-section",
-        cl::desc("Make the `.llvmbc` section loadable"), cl::NotHidden,
-        cl::location(YkAllocLLVMBCSection));
-  }
-};
-} // namespace
-static ManagedStatic<cl::opt<bool, true>, CreateYkAllocLLVMBCSectionParser>
-    YkAllocLLVMBCSectionParser;
-
-bool YkAllocLLVMBBAddrMapSection;
-namespace {
-struct CreateYkAllocLLVMBBAddrMapSectionParser {
-  static void *call() {
-    return new cl::opt<bool, true>(
-        "yk-alloc-llvmbbaddrmap-section",
-        cl::desc("Make the `.llvmbbaddrmap` section loadable"), cl::NotHidden,
-        cl::location(YkAllocLLVMBBAddrMapSection));
-  }
-};
-} // namespace
-static ManagedStatic<cl::opt<bool, true>,
-                     CreateYkAllocLLVMBBAddrMapSectionParser>
-    YkAllocLLVMBBAddrMapSectionParser;
-
 bool YkExtendedLLVMBBAddrMapSection;
 namespace {
 struct CreateYkExtendedLLVMBBAddrMapSectionParser {
@@ -126,8 +97,6 @@ struct CreateYkEmbedIRParser {
 static ManagedStatic<cl::opt<bool, true>, CreateYkEmbedIRParser> YkEmbedIRParser;
 
 void llvm::initYkOptions() {
-  *YkAllocLLVMBCSectionParser;
-  *YkAllocLLVMBBAddrMapSectionParser;
   *YkExtendedLLVMBBAddrMapSectionParser;
   *YkStackMapOffsetFixParser;
   *YkStackMapAdditionalLocsParser;


### PR DESCRIPTION
It's not clear if it's correct to be SHF_ALLOCing these sections, so we err on the side of caution and don't.

For more info, see:
https://github.com/ykjit/yk/issues/923

Companion to https://github.com/ykjit/yk/pull/927