### PR TITLE
Yk assumes all pointers are the same size as a void pointer.

### DIFF
--- a/llvm/lib/YkIR/YkIRWriter.cpp
+++ b/llvm/lib/YkIR/YkIRWriter.cpp
@@ -494,7 +494,9 @@ private:
   void serialiseType(llvm::Type *Ty) {
     if (Ty->isVoidTy()) {
       OutStreamer.emitInt8(TypeKind::Void);
-    } else if (Ty->isPointerTy()) {
+    } else if (PointerType *PT = dyn_cast<PointerType>(Ty)) {
+      // FIXME: The Yk runtime assumes all pointers are void-ptr-sized.
+      assert(DL.getPointerSize(PT->getAddressSpace()) == sizeof(void *));
       OutStreamer.emitInt8(TypeKind::Ptr);
     } else if (IntegerType *ITy = dyn_cast<IntegerType>(Ty)) {
       OutStreamer.emitInt8(TypeKind::Integer);


### PR DESCRIPTION
I think this addresses [this comment](https://github.com/ykjit/yk/pull/991#discussion_r1502675230)?

I wasn't sure whether to use `sizeof(uintptr_t)` or `sizeof(void *)`. Are they the same?

(untested btw :) )