### PR TITLE
Resurrecting Stackmap insertion change

### DIFF
--- a/llvm/lib/Transforms/Yk/StackMaps.cpp
+++ b/llvm/lib/Transforms/Yk/StackMaps.cpp
@@ -15,8 +15,8 @@
 #include "llvm/IR/Verifier.h"
 #include "llvm/InitializePasses.h"
 #include "llvm/Pass.h"
-#include "llvm/Transforms/Yk/LivenessAnalysis.h"
 #include "llvm/Transforms/Yk/ControlPoint.h"
+#include "llvm/Transforms/Yk/LivenessAnalysis.h"
 #include <map>
 
 #define DEBUG_TYPE "yk-stackmaps"
@@ -60,12 +60,12 @@ public:
             // We don't need to insert stackmaps after intrinsics. But since we
             // can't tell if an indirect call is an intrinsic at compile time,
             // emit a stackmap in those cases too.
-            
+
             if (!CI.isIndirectCall() &&
                 (CI.getCalledFunction()->isIntrinsic() ||
                  (CI.getCalledFunction()->isDeclaration() &&
                   (!CI.getCalledFunction()->getName().startswith(
-                       "yk_promote") &&
+                       "__yk_promote") &&
                    CI.getCalledFunction()->getName() != YK_NEW_CONTROL_POINT))))
               continue;
 


### PR DESCRIPTION
These changes make sure that stackmap is not inserted after unmappable functions except control point and yk_promote calls. In previous PR https://github.com/ykjit/ykllvm/pull/114 the stackmaps insertion was skipped as control point and yk_promote were treated as external functions, which resulted in some tests failing. This commit make sures that this problem don't occur while retaining the logic of previous PR.