### PR TITLE
Reverting to get back the stackmap changes.

### DIFF
--- a/llvm/lib/Transforms/Yk/StackMaps.cpp
+++ b/llvm/lib/Transforms/Yk/StackMaps.cpp
@@ -15,8 +15,8 @@
 #include "llvm/IR/Verifier.h"
 #include "llvm/InitializePasses.h"
 #include "llvm/Pass.h"
+#include "llvm/Transforms/Yk/ControlPoint.h"
 #include "llvm/Transforms/Yk/LivenessAnalysis.h"
-
 #include <map>
 
 #define DEBUG_TYPE "yk-stackmaps"
@@ -60,8 +60,15 @@ public:
             // We don't need to insert stackmaps after intrinsics. But since we
             // can't tell if an indirect call is an intrinsic at compile time,
             // emit a stackmap in those cases too.
-            if (!CI.isIndirectCall() && CI.getCalledFunction()->isIntrinsic())
+
+            if (!CI.isIndirectCall() &&
+                (CI.getCalledFunction()->isIntrinsic() ||
+                 (CI.getCalledFunction()->isDeclaration() &&
+                  (!CI.getCalledFunction()->getName().startswith(
+                       "__yk_promote") &&
+                   CI.getCalledFunction()->getName() != YK_NEW_CONTROL_POINT))))
               continue;
+
             SMCalls.insert({&I, LA.getLiveVarsBefore(&I)});
           } else if ((isa<BranchInst>(I) &&
                       cast<BranchInst>(I).isConditional()) ||


### PR DESCRIPTION
These changes make sure that stackmap is not inserted after unmappable functions except control point and yk_promote calls.
