### PR TITLE
Reverting the stackmap change

### DIFF
--- a/llvm/lib/Transforms/Yk/StackMaps.cpp
+++ b/llvm/lib/Transforms/Yk/StackMaps.cpp
@@ -15,8 +15,8 @@
 #include "llvm/IR/Verifier.h"
 #include "llvm/InitializePasses.h"
 #include "llvm/Pass.h"
-#include "llvm/Transforms/Yk/ControlPoint.h"
 #include "llvm/Transforms/Yk/LivenessAnalysis.h"
+
 #include <map>
 
 #define DEBUG_TYPE "yk-stackmaps"
@@ -60,15 +60,8 @@ public:
             // We don't need to insert stackmaps after intrinsics. But since we
             // can't tell if an indirect call is an intrinsic at compile time,
             // emit a stackmap in those cases too.
-
-            if (!CI.isIndirectCall() &&
-                (CI.getCalledFunction()->isIntrinsic() ||
-                 (CI.getCalledFunction()->isDeclaration() &&
-                  (!CI.getCalledFunction()->getName().startswith(
-                       "__yk_promote") &&
-                   CI.getCalledFunction()->getName() != YK_NEW_CONTROL_POINT))))
+            if (!CI.isIndirectCall() && CI.getCalledFunction()->isIntrinsic())
               continue;
-
             SMCalls.insert({&I, LA.getLiveVarsBefore(&I)});
           } else if ((isa<BranchInst>(I) &&
                       cast<BranchInst>(I).isConditional()) ||


### PR DESCRIPTION
This commit reverts the stackmap change as it breaks the YK test suite. 
