### PR TITLE
Create a global `__yk_globalvar_len` with the number of global variables

### DIFF
--- a/llvm/lib/YkIR/YkIRWriter.cpp
+++ b/llvm/lib/YkIR/YkIRWriter.cpp
@@ -815,6 +815,11 @@ public:
         M, GlobalsArrayTy, true, GlobalValue::LinkageTypes::ExternalLinkage,
         ConstantArray::get(GlobalsArrayTy, GlobalsAsConsts));
     GlobalsArray->setName("__yk_globalvar_ptrs");
+    IntegerType *Int64Ty = Type::getInt64Ty(M.getContext());
+    GlobalVariable *GlobalsArrayLen = new GlobalVariable(
+        M, Int64Ty, true, GlobalValue::LinkageTypes::ExternalLinkage,
+        ConstantInt::get(Int64Ty, Globals.size()));
+    GlobalsArrayLen->setName("__yk_globalvar_len");
 
     // num_types:
     OutStreamer.emitSizeT(Types.size());


### PR DESCRIPTION
We don't *strictly* need to do this, because we can assume the IR references are all correct. But passing this information to run-time gives us extra assurance, at very little cost, that we haven't done anything wrong.

See yk PR https://github.com/ykjit/yk/pull/1066.