### PR TITLE
Namespace enums in the serialiser.

### DIFF
--- a/llvm/lib/YkIR/YkIRWriter.cpp
+++ b/llvm/lib/YkIR/YkIRWriter.cpp
@@ -36,19 +36,19 @@ const uint32_t Magic = 0xedd5f00d;
 const uint32_t Version = 0;
 
 enum OpCode {
-  Nop = 0,
-  Load,
-  Store,
-  Alloca,
-  Call,
-  Br,
-  CondBr,
-  ICmp,
-  Ret,
-  InsertValue,
-  PtrAdd,
-  BinOp,
-  UnimplementedInstruction = 255, // YKFIXME: Will eventually be deleted.
+  OpCodeNop = 0,
+  OpCodeLoad,
+  OpCodeStore,
+  OpCodeAlloca,
+  OpCodeCall,
+  OpCodeBr,
+  OpCodeCondBr,
+  OpCodeICmp,
+  OpCodeRet,
+  OpCodeInsertValue,
+  OpCodePtrAdd,
+  OpCodeBinOp,
+  OpCodeUnimplemented = 255, // YKFIXME: Will eventually be deleted.
 };
 
 enum OperandKind {
@@ -290,7 +290,7 @@ private:
     assert(I->getNumOperands() == 2);
 
     // opcode:
-    OutStreamer.emitInt8(OpCode::BinOp);
+    serialiseOpcode(OpCodeBinOp);
     // left-hand side:
     serialiseOperand(I, VLMap, I->getOperand(0));
     // binary operator:
@@ -370,7 +370,7 @@ private:
   void serialiseAllocaInst(AllocaInst *I, ValueLoweringMap &VLMap,
                            unsigned BBIdx, unsigned &InstIdx) {
     // opcode:
-    serialiseOpcode(OpCode::Alloca);
+    serialiseOpcode(OpCodeAlloca);
 
     // type to be allocated:
     OutStreamer.emitSizeT(typeIndex(I->getAllocatedType()));
@@ -418,7 +418,7 @@ private:
     assert(I->getCalledFunction());
 
     // opcode:
-    serialiseOpcode(OpCode::Call);
+    serialiseOpcode(OpCodeCall);
     // callee:
     OutStreamer.emitSizeT(functionIndex(I->getCalledFunction()));
     // num_args:
@@ -445,10 +445,10 @@ private:
       // traces will guide us.
       //
       // opcode:
-      serialiseOpcode(OpCode::Br);
+      serialiseOpcode(OpCodeBr);
     } else {
       // opcode:
-      serialiseOpcode(OpCode::CondBr);
+      serialiseOpcode(OpCodeCondBr);
       // We DO need operands for conditional branches, so that we can build
       // guards.
       //
@@ -465,7 +465,7 @@ private:
   void serialiseLoadInst(LoadInst *I, ValueLoweringMap &VLMap, unsigned BBIdx,
                          unsigned &InstIdx) {
     // opcode:
-    serialiseOpcode(OpCode::Load);
+    serialiseOpcode(OpCodeLoad);
     // ptr:
     serialiseOperand(I, VLMap, I->getPointerOperand());
     // type_idx:
@@ -478,7 +478,7 @@ private:
   void serialiseStoreInst(StoreInst *I, ValueLoweringMap &VLMap, unsigned BBIdx,
                           unsigned &InstIdx) {
     // opcode:
-    serialiseOpcode(OpCode::Store);
+    serialiseOpcode(OpCodeStore);
     // value:
     serialiseOperand(I, VLMap, I->getValueOperand());
     // ptr:
@@ -497,7 +497,7 @@ private:
     assert(Res);
 
     // opcode:
-    serialiseOpcode(OpCode::PtrAdd);
+    serialiseOpcode(OpCodePtrAdd);
     // type_idx:
     OutStreamer.emitSizeT(typeIndex(I->getType()));
     // pointer:
@@ -552,7 +552,7 @@ private:
   void serialiseICmpInst(ICmpInst *I, ValueLoweringMap &VLMap, unsigned BBIdx,
                          unsigned &InstIdx) {
     // opcode:
-    serialiseOpcode(OpCode::ICmp);
+    serialiseOpcode(OpCodeICmp);
     // type_idx:
     OutStreamer.emitSizeT(typeIndex(I->getType()));
     // lhs:
@@ -569,7 +569,7 @@ private:
   void serialiseReturnInst(ReturnInst *I, ValueLoweringMap &VLMap,
                            unsigned BBIdx, unsigned &InstIdx) {
     // opcode:
-    serialiseOpcode(OpCode::Ret);
+    serialiseOpcode(OpCodeRet);
 
     Value *RV = I->getReturnValue();
     if (RV == nullptr) {
@@ -588,7 +588,7 @@ private:
   void serialiseInsertValueInst(InsertValueInst *I, ValueLoweringMap &VLMap,
                                 unsigned BBIdx, unsigned &InstIdx) {
     // opcode:
-    serialiseOpcode(OpCode::InsertValue);
+    serialiseOpcode(OpCodeInsertValue);
     // agg:
     serialiseOperand(I, VLMap, I->getAggregateOperand());
     // elem:
@@ -626,7 +626,7 @@ private:
                                          ValueLoweringMap &VLMap,
                                          unsigned BBIdx, unsigned &InstIdx) {
     // opcode:
-    serialiseOpcode(UnimplementedInstruction);
+    serialiseOpcode(OpCodeUnimplemented);
     // stringified problem instruction
     serialiseString(toString(I));
 

--- a/llvm/lib/YkIR/YkIRWriter.cpp
+++ b/llvm/lib/YkIR/YkIRWriter.cpp
@@ -203,8 +203,8 @@ private:
 
   // Return the index of the LLVM global `G`, inserting a new entry if
   // necessary.
-  size_t globalIndex(class GlobalVariable *G) {
-    vector<class GlobalVariable *>::iterator Found =
+  size_t globalIndex(GlobalVariable *G) {
+    vector<GlobalVariable *>::iterator Found =
         std::find(Globals.begin(), Globals.end(), G);
     if (Found != Globals.end()) {
       return std::distance(Globals.begin(), Found);
@@ -790,7 +790,7 @@ private:
     }
   }
 
-  void serialiseGlobal(class GlobalVariable *G) {
+  void serialiseGlobal(GlobalVariable *G) {
     OutStreamer.emitInt8(G->isThreadLocal());
     serialiseString(G->getName());
   }
@@ -829,7 +829,7 @@ public:
     // num_globals:
     OutStreamer.emitSizeT(Globals.size());
     // globals:
-    for (class GlobalVariable *&G : Globals) {
+    for (GlobalVariable *&G : Globals) {
       serialiseGlobal(G);
     }
 


### PR DESCRIPTION
A couple of surprising things about C++:

 - Two enums may not have a same-named variant (i.e. discriminants are not namespaced by the parent type).
 - A class may be named the same as an enum variant, but when you come to use either, you may have to disambiguate with a hint to the compiler.

Further, in quite a few places our names clash with LLVM's.

This change "namespaces" all of our AOT IR enums such that clashes should never happen, and hints are therefore not required.

Note that there is `enum class` from C++11, which is a "scoped enum", but getting at the underlying discriminant number was only implemented in C++23, which I doubt our compiler supports yet. Our stuff requires getting the number.

