### PR TITLE
Ignore `exact` keywords for binary operations.

### DIFF
--- a/llvm/lib/YkIR/YkIRWriter.cpp
+++ b/llvm/lib/YkIR/YkIRWriter.cpp
@@ -373,19 +373,16 @@ private:
 
     // We don't yet support:
     //  - fast math flags (for float operations).
-    //  - the `exact` keyword
     //  - vector variants
     if ((isa<FPMathOperator>(I) && (I->getFastMathFlags().any())) ||
-        (isa<PossiblyExactOperator>(I) && I->isExact()) ||
         I->getType()->isVectorTy()) {
       serialiseUnimplementedInstruction(I, FLCtxt, BBIdx, InstIdx);
       return;
     }
 
     // Note that we do nothing with the `nsw` and `nuw` (no {signed,unsigned}
-    // wrap) keywords, which may generate poison values. If they do, the rules
-    // of deferred UB allow us to make any value we wish, including (as
-    // we do) the wrapped value.
+    // wrap), and `exact` keywords, which may generate poison values. If they
+    // do, the rules of deferred UB allow us to make any value we wish.
 
     // opcode:
     serialiseOpcode(OpCodeBinOp);


### PR DESCRIPTION
Until we start optimising traces we don't need to worry about them.