### PR TITLE
Making mem2reg compatible with yk [DRAFT]

### DIFF
--- a/llvm/lib/Transforms/Utils/Mem2Reg.cpp
+++ b/llvm/lib/Transforms/Utils/Mem2Reg.cpp
@@ -43,10 +43,10 @@ static bool promoteMemoryToRegister(Function &F, DominatorTree &DT,
 
     // Find allocas that are safe to promote, by looking at all instructions in
     // the entry node
-    for (BasicBlock::iterator I = BB.begin(), E = --BB.end(); I != E; ++I)
-      if (AllocaInst *AI = dyn_cast<AllocaInst>(I)) // Is it an alloca?
-        if (isAllocaPromotable(AI))
-          Allocas.push_back(AI);
+    // for (BasicBlock::iterator I = BB.begin(), E = --BB.end(); I != E; ++I)
+    //   if (AllocaInst *AI = dyn_cast<AllocaInst>(I)) // Is it an alloca?
+    //     if (isAllocaPromotable(AI))
+    //       Allocas.push_back(AI);
 
     if (Allocas.empty())
       break;


### PR DESCRIPTION
Enabling mem2reg pass in the middle-end pipeline results in yk test cases to fail. There are two type of failure:
1) The stderr doesn't match (could be that IR doesn't match)
2) Some tests never terminate (all of which uses `yk_promote`)

A very simple way to reproduce this would be to set `export PRELINK_PASSES="mem2reg"` and then run `cargo test`.
Commenting the block which promote allocas to phi node seem to resolve the failures.

I'll keep on adding my findings as I go about finding them in this PR.