### PR TITLE
Fold stackmaps into control point during lowering.

### DIFF
--- a/llvm/lib/YkIR/YkIRWriter.cpp
+++ b/llvm/lib/YkIR/YkIRWriter.cpp
@@ -4,6 +4,7 @@
 //
 //===-------------------------------------------------------------------===//
 
+#include "llvm/Analysis/ConstantFolding.h"
 #include "llvm/BinaryFormat/ELF.h"
 #include "llvm/IR/Constant.h"
 #include "llvm/IR/Constants.h"
@@ -18,6 +19,7 @@
 #include "llvm/MC/MCSectionELF.h"
 #include "llvm/MC/MCStreamer.h"
 #include "llvm/Support/ErrorHandling.h"
+#include "llvm/Transforms/Yk/ControlPoint.h"
 
 using namespace llvm;
 using namespace std;
@@ -693,7 +695,9 @@ private:
     for (unsigned OI = 0; OI < I->arg_size(); OI++) {
       serialiseOperand(I, FLCtxt, I->getOperand(OI));
     }
-    if (!I->getCalledFunction()->isDeclaration()) {
+    bool IsCtrlPointCall =
+        I->getCalledFunction()->getName() == YK_NEW_CONTROL_POINT;
+    if (!I->getCalledFunction()->isDeclaration() || IsCtrlPointCall) {
       // The next instruction will be the stackmap entry
       // has_safepoint = 1:
       OutStreamer.emitInt8(1);


### PR DESCRIPTION
We currently don't fold stackmaps into the control point during lowering. However, the control point stackmap is required for side-tracing.

We also need to remove the `frameaddr` live variable from the control point's stackmap as this is not required and removing it at runtime is more difficult than doing it here.