### PR TITLE
Don't adjust shadowstack for external calls.

### DIFF
--- a/llvm/lib/Transforms/Yk/ShadowStack.cpp
+++ b/llvm/lib/Transforms/Yk/ShadowStack.cpp
@@ -188,10 +188,12 @@ public:
             // IR for.
 
             if (CI.getCalledFunction()) {
-              // Skip some known intrinsics. YKFIXME: Is there a more general
-              // solution, e.g. skip all intrinsics?
-              if (CI.getCalledFunction()->getName() ==
-                  "llvm.experimental.stackmap") {
+              if (CI.getCalledFunction()->isIntrinsic()) {
+                // Skip intrinsics.
+                continue;
+              }
+              if (CI.getCalledFunction()->isDeclaration()) {
+                // Skip external functions.
                 continue;
               }
               if (CI.getCalledFunction()->getName() == "llvm.dbg.declare") {


### PR DESCRIPTION
External calls don't use the shadow stack so there's no need to adjust it.