### PR TITLE
Pass the stackmap id into the control point.

### DIFF
--- a/llvm/lib/Transforms/Yk/StackMaps.cpp
+++ b/llvm/lib/Transforms/Yk/StackMaps.cpp
@@ -103,6 +103,9 @@ public:
         CallInst &CI = cast<CallInst>(*I);
         if (!CI.isIndirectCall() &&
             CI.getCalledFunction()->getName() == YK_NEW_CONTROL_POINT) {
+          // Update the stackmap id passed into the control point.
+          unsigned ArgSize = CI.arg_size();
+          CI.setArgOperand(ArgSize - 1, SMID);
           assert(isa<IntrinsicInst>(Args.back()) &&
                  cast<IntrinsicInst>(Args.back())->getIntrinsicID() ==
                      Intrinsic::frameaddress);


### PR DESCRIPTION
This allows the control point to find and access its stackmap. We will later use this to get rid of the trace inputs struct.