### PR TITLE
Assert type of global variables.

### DIFF
--- a/llvm/lib/YkIR/YkIRWriter.cpp
+++ b/llvm/lib/YkIR/YkIRWriter.cpp
@@ -1611,6 +1611,7 @@ private:
   }
 
   void serialiseGlobal(GlobalVariable *G) {
+    assert(G->getType()->isPointerTy());
     OutStreamer.emitInt8(G->isThreadLocal());
     serialiseString(G->getName());
   }


### PR DESCRIPTION
In LLVM IR globals are always pointer-typed, and to access them you always have to use loads and stores.

We are going to carry this assumption to the Yk IRs, so I thought it best to add an assertion.