### PR TITLE
Add types to unimplemented AOT consts.

### DIFF
--- a/llvm/lib/YkIR/YkIRWriter.cpp
+++ b/llvm/lib/YkIR/YkIRWriter.cpp
@@ -1569,6 +1569,8 @@ private:
   void serialiseUnimplementedConstant(Constant *C) {
     // `Const` discriminator:
     OutStreamer.emitInt8(ConstKindUnimplemented);
+    // tyidx:
+    OutStreamer.emitSizeT(typeIndex(C->getType()));
     // problem constant, stringified:
     serialiseString(toString(C));
   }


### PR DESCRIPTION
Required to fix an AOT IR printing crash.