### PR TITLE
Remove trace inputs struct passed into the control point.

### DIFF
--- a/llvm/lib/Transforms/Yk/StackMaps.cpp
+++ b/llvm/lib/Transforms/Yk/StackMaps.cpp
@@ -106,12 +106,6 @@ public:
           // Update the stackmap id passed into the control point.
           unsigned ArgSize = CI.arg_size();
           CI.setArgOperand(ArgSize - 1, SMID);
-          assert(isa<IntrinsicInst>(Args.back()) &&
-                 cast<IntrinsicInst>(Args.back())->getIntrinsicID() ==
-                     Intrinsic::frameaddress);
-          // Remove the last live argument which is the frameaddr which we have
-          // no use for and is difficult to remove during tracing.
-          Args.pop_back();
         }
       }
       Bldr.CreateCall(SMFunc->getFunctionType(), SMFunc,


### PR DESCRIPTION
We recently introduced a way to read trace inputs directly via their registers and stack locations in the parent frame. The former trace inputs struct is thus no longer needed. Similarly, we no longer need to use the `frameaddr` intrinsic which can be removed too.