### PR TITLE
Fix spillmap algorithm.

### DIFF
--- a/llvm/lib/Target/X86/X86AsmPrinter.cpp
+++ b/llvm/lib/Target/X86/X86AsmPrinter.cpp
@@ -134,8 +134,8 @@ void processInstructions(
       const Register Reg = MO.getReg();
       if (OffsetOp.isImm()) {
         const int64_t Offset = OffsetOp.getImm();
-        SpillMap[Reg] = Offset;
         clearRhs(Reg, SpillMap);
+        SpillMap[Reg] = Offset;
       }
       continue;
     }
@@ -149,8 +149,8 @@ void processInstructions(
       const Register Reg = Lhs.getReg();
       if (OffsetOp.isImm()) {
         const int64_t Offset = OffsetOp.getImm();
-        SpillMap[Reg] = Offset;
         clearRhs(Reg, SpillMap);
+        SpillMap[Reg] = Offset;
       }
       continue;
     }


### PR DESCRIPTION
This algorithm works out the additional (register/stack) locations of live variables and stores them inside stackmaps.

There's a part of the algorithm that transitively applies mappings from one register to another (e.g. when one mapping is overwritten). However, we were doing this AFTER we had already overwritten the old mappinng, when we should have applied the old mapping instead.

This commit puts things in the correct order.