### PR TITLE
LLVM module clone

### DIFF
--- a/llvm/lib/YkIR/CMakeLists.txt
+++ b/llvm/lib/YkIR/CMakeLists.txt
@@ -5,4 +5,6 @@ add_llvm_component_library(LLVMYkIR
   Core
   MC
   Support
+  TransformUtils
+  Linker
   )

--- a/llvm/lib/YkIR/YkIRWriter.cpp
+++ b/llvm/lib/YkIR/YkIRWriter.cpp
@@ -1794,7 +1794,6 @@ void cloneModule(Module &M) {
   if (!ClonedModule) {
     llvm::report_fatal_error(StringRef("attempt to clone module failed"));
   }
-  ClonedModule->setModuleIdentifier(ClonePrefix + M.getName().str());
   // Rename functions
   for (llvm::Function &F : *ClonedModule) {
     if (F.hasExternalLinkage() && F.isDeclaration()) {

--- a/llvm/lib/YkIR/YkIRWriter.cpp
+++ b/llvm/lib/YkIR/YkIRWriter.cpp
@@ -4,8 +4,6 @@
 //
 //===-------------------------------------------------------------------===//
 
-#include "llvm/Transforms/Utils/Cloning.h"
-#include "llvm/Linker/Linker.h"
 #include "llvm/Analysis/ConstantFolding.h"
 #include "llvm/BinaryFormat/ELF.h"
 #include "llvm/IR/Constant.h"
@@ -18,10 +16,12 @@
 #include "llvm/IR/Intrinsics.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Operator.h"
+#include "llvm/Linker/Linker.h"
 #include "llvm/MC/MCContext.h"
 #include "llvm/MC/MCSectionELF.h"
 #include "llvm/MC/MCStreamer.h"
 #include "llvm/Support/ErrorHandling.h"
+#include "llvm/Transforms/Utils/Cloning.h"
 #include "llvm/Transforms/Yk/ControlPoint.h"
 
 using namespace llvm;
@@ -1808,8 +1808,8 @@ void cloneModule(Module &M) {
     if (GlobalName.find('.') == 0) {
       continue; // This is likely not user-defined. Example: `.L.str`.
     }
-    GV.setInitializer(nullptr);                        
-    GV.setLinkage(llvm::GlobalValue::ExternalLinkage); 
+    GV.setInitializer(nullptr);
+    GV.setLinkage(llvm::GlobalValue::ExternalLinkage);
   }
 
   // Link both modules


### PR DESCRIPTION
LLVM module clone:
- Clone original module and r
- Rename function names buy adding a `__yk_clone_` prefix
- Set global variables to be exernal

Example of original and cloned functions:
```ir
func func_example(%arg0: i32) -> i32 {
  bb0:
....
func __yk_clone_func_example(%arg0: i32) -> i32 {
  bb0:
...
```

[Combined module ir](https://github.com/user-attachments/files/17002052/module.txt)
