### PR TITLE
Allow tracking of arbitrarily many locations.

### DIFF
--- a/llvm/include/llvm/CodeGen/StackMaps.h
+++ b/llvm/include/llvm/CodeGen/StackMaps.h
@@ -196,11 +196,14 @@ public:
     unsigned Size = 0;
     unsigned Reg = 0;
     int64_t Offset = 0;
-    unsigned ExtraReg = 0;
+    /// Additional locations for this live variable. Positive values are
+    /// registers in Dwarf notation. Negative values are offsets relative to
+    /// RBP.
+    std::set<int64_t> Extras;
 
     Location() = default;
-    Location(LocationType Type, unsigned Size, unsigned Reg, int64_t Offset, unsigned ExtraReg = 0)
-        : Type(Type), Size(Size), Reg(Reg), Offset(Offset), ExtraReg(ExtraReg) {}
+    Location(LocationType Type, unsigned Size, unsigned Reg, int64_t Offset, std::set<int64_t> Extras = {})
+        : Type(Type), Size(Size), Reg(Reg), Offset(Offset), Extras(Extras) {}
   };
 
   struct LiveOutReg {

--- a/llvm/test/CodeGen/X86/statepoint-stackmap-size.ll
+++ b/llvm/test/CodeGen/X86/statepoint-stackmap-size.ll
@@ -4,7 +4,7 @@
 ; spaces) starting with a `.` follow (e.g. `  .byte`).
 ;
 ;      CHECK:	.section	.llvm_stackmaps,{{.*$}}
-; CHECK-NEXT:{{(.+$[[:space:]]){54}[[:space:]]}}
+; CHECK-NEXT:{{(.+$[[:space:]]){51}[[:space:]]}}
 ; CHECK-SAME: .section
 
 target triple = "x86_64-pc-linux-gnu"

--- a/llvm/test/CodeGen/X86/yk-stackmaps-extrareg.ll
+++ b/llvm/test/CodeGen/X86/yk-stackmaps-extrareg.ll
@@ -9,10 +9,14 @@
 ; CHECK-NEXT: .short 8
 ; NOTE: Actual tracked register
 ; CHECK-NEXT: .short 13
-; NOTE: Extra register this value is stored in (normally 0)
-; CHECK-NEXT: .short 9
-; NOTE: Stack offset this value is stored in (normally 0)
-; CHECK-NEXT: .long -80
+; NOTE: Reserved
+; CHECK-NEXT: .short 0
+; NOTE: Number of extra locations.
+; CHECK-NEXT: .short 2
+; NOTE: Stack offset this value is stored in.
+; CHECK-NEXT: .short -80
+; NOTE: Extra register this value is stored in.
+; CHECK-NEXT: .short 8
 
 source_filename = "ld-temp.o"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"


### PR DESCRIPTION
We've previously relied on a hack to track up to two additional locations per live variable. This worked out for us until now that we are seeing variables with more locations than we can deal with. This commit extends stackmaps properly so that we can track arbitrarily many locations for each live variable.