### PR TITLE
Fix missing register tracking in the spillmap analysis.

### DIFF
--- a/llvm/lib/Target/X86/X86AsmPrinter.cpp
+++ b/llvm/lib/Target/X86/X86AsmPrinter.cpp
@@ -131,6 +131,8 @@ void processInstructions(
       // Transitively apply the mappings of `Rhs` to this mapping too.
       std::set<int64_t> Other = SpillMap[RhsDwReg];
       SpillMap[LhsDwReg].insert(Other.begin(), Other.end());
+      // Also add Lhs to the mapping of Rhs.
+      SpillMap[RhsDwReg].insert(LhsDwReg);
       continue;
     }
 


### PR DESCRIPTION
Tickled by software tracing, whose extra calls to the recorder caused LLVM to emit a shape of code we've not seen before.

This is the fix for the CI failure in https://github.com/ykjit/yk/pull/1400