### PR TITLE
Allow serialisation of call arguments with safe align attributes.

### DIFF
--- a/llvm/lib/YkIR/YkIRWriter.cpp
+++ b/llvm/lib/YkIR/YkIRWriter.cpp
@@ -699,6 +699,19 @@ private:
         if (Attr.getKindAsEnum() == Attribute::AllocSize) {
           continue;
         }
+
+        if (Attr.getKindAsEnum() == Attribute::Alignment) {
+          // Following what we do with loads/stores, we accept any alignment
+          // value greater-than or equal-to the size of the object.
+          //
+          // FIXME: explicitly encode the alignment requirements into the IR
+          // and let the JIT codegen deal with it.
+          if (I->getParamAlign(AI) >=
+              DL.getTypeAllocSize(I->getArgOperand(AI)->getType())) {
+            continue;
+          }
+        }
+
         serialiseUnimplementedInstruction(I, FLCtxt, BBIdx, InstIdx);
         return;
       }


### PR DESCRIPTION
This change permits the yk IR serialiser to serialise calls whose arguments use safe `align` attributes.

Following the precedent of loads and stores, a safe alignment is one that is at least the size of the object being aligned. The JIT's code generator doesn't need to do anything special with such alignments.

(We do plan to change our strategy and encode the alignment requirements explicitly into the IR and defer what to do with it to the JIT codegen, but now isn't the time)

This allows us to handle calls like this:

```
call void @llvm.memcpy.p0.p0.i64(ptr noundef nonnull align 8 dereferenceable(48) %3568, ptr noundef nonnull align 8 dereferenceable(48) %3567, i64 48, i1 false
```

This one was found in the wild in the LuaJIT test suite.