### PR TITLE
Serialise `fneg` instructions.

### DIFF
--- a/llvm/lib/YkIR/YkIRWriter.cpp
+++ b/llvm/lib/YkIR/YkIRWriter.cpp
@@ -73,6 +73,7 @@ enum OpCode {
   OpCodeLoadArg,
   OpCodeFCmp,
   OpCodePromote,
+  OpCodeFNeg,
   OpCodeUnimplemented = 255, // YKFIXME: Will eventually be deleted.
 };
 
@@ -1382,6 +1383,21 @@ private:
     InstIdx++;
   }
 
+  void serialiseUnaryOperatorInst(UnaryOperator *I, FuncLowerCtxt &FLCtxt,
+                                  unsigned BBIdx, unsigned &InstIdx) {
+    if (I->getOpcode() == UnaryOperator::UnaryOps::FNeg) {
+      // opcode:
+      serialiseOpcode(OpCodeFNeg);
+      // value:
+      serialiseOperand(I, FLCtxt, I->getOperand(0));
+
+      FLCtxt.updateVLMap(I, InstIdx);
+      InstIdx++;
+    } else {
+      serialiseUnimplementedInstruction(I, FLCtxt, BBIdx, InstIdx);
+    }
+  }
+
   size_t getPathIndex(string Path) {
     vector<string>::iterator It = std::find(Paths.begin(), Paths.end(), Path);
     if (It != Paths.end()) {
@@ -1463,6 +1479,7 @@ private:
     INST_SERIALISE(I, StoreInst, serialiseStoreInst);
     INST_SERIALISE(I, SwitchInst, serialiseSwitchInst);
     INST_SERIALISE(I, SelectInst, serialiseSelectInst);
+    INST_SERIALISE(I, UnaryOperator, serialiseUnaryOperatorInst);
 
     // INST_SERIALISE does an early return upon a match, so if we get here then
     // the instruction wasn't handled.


### PR DESCRIPTION
Required for LuaJIT tests.