### PR TITLE
Prevent JumpThreadingPass from messing with control points.

### DIFF
--- a/llvm/include/llvm/Support/Yk.h
+++ b/llvm/include/llvm/Support/Yk.h
@@ -9,5 +9,6 @@ void initYkOptions(void);
 // of us randomly introducing `extern bool`s all over the place.
 extern bool YkOptNoneAfterIRPasses;
 extern bool YkDontOptFuncABI;
+extern bool YkPatchCtrlPoint;
 
 #endif

--- a/llvm/lib/CodeGen/TargetPassConfig.cpp
+++ b/llvm/lib/CodeGen/TargetPassConfig.cpp
@@ -44,6 +44,7 @@
 #include "llvm/Support/Threading.h"
 #include "llvm/Support/VirtualFileSystem.h"
 #include "llvm/Support/WithColor.h"
+#include "llvm/Support/Yk.h"
 #include "llvm/Target/CGPassBuilderOption.h"
 #include "llvm/Target/TargetMachine.h"
 #include "llvm/Transforms/Scalar.h"
@@ -269,10 +270,6 @@ static cl::opt<bool>
 static cl::opt<bool>
     YkBlockDisambiguate("yk-block-disambiguate", cl::init(false), cl::NotHidden,
                         cl::desc("Disambiguate blocks for yk"));
-
-static cl::opt<bool> YkPatchCtrlPoint("yk-patch-control-point", cl::init(false),
-                                      cl::NotHidden,
-                                      cl::desc("Patch yk_mt_control_point()"));
 
 static cl::opt<bool> YkLinkage("yk-linkage", cl::init(false),
                                       cl::NotHidden,

--- a/llvm/lib/Support/Yk.cpp
+++ b/llvm/lib/Support/Yk.cpp
@@ -110,6 +110,20 @@ struct CreateYkDontOptFuncABIParser {
 } // namespace
 static ManagedStatic<cl::opt<bool, true>, CreateYkDontOptFuncABIParser> YkDontOptFuncABIParser;
 
+bool YkPatchCtrlPoint;
+namespace {
+struct CreateYkPatchCtrlPointParser {
+  static void *call() {
+    return new cl::opt<bool, true>(
+        "yk-patch-control-point",
+        cl::desc("Patch yk control points"),
+        cl::NotHidden, cl::location(YkPatchCtrlPoint));
+  }
+};
+} // namespace
+static ManagedStatic<cl::opt<bool, true>, CreateYkPatchCtrlPointParser> YkPatchCtrlPointParser;
+
+
 void llvm::initYkOptions() {
   *YkExtendedLLVMBBAddrMapSectionParser;
   *YkStackMapOffsetFixParser;
@@ -118,4 +132,5 @@ void llvm::initYkOptions() {
   *YkOptNoneAfterIRPassesParser;
   *YkEmbedIRParser;
   *YkDontOptFuncABIParser;
+  *YkPatchCtrlPointParser;
 }


### PR DESCRIPTION
Requires moving the -yk-patch-ctrl-point flag so it's accessible in two places.