### PR TITLE
Make sure that unoptimised functions calls ONLY unoptimised functions.

### DIFF
--- a/llvm/include/llvm/Transforms/Yk/ModuleClone.h
+++ b/llvm/include/llvm/Transforms/Yk/ModuleClone.h
@@ -3,7 +3,7 @@
 
 #include "llvm/Pass.h"
 
-#define YK_CLONE_PREFIX "__yk_clone_"
+#define YK_CLONE_PREFIX "__yk_opt_"
 #define YK_CLONE_MODULE_CP_COUNT 2
 
 namespace llvm {

--- a/llvm/lib/Transforms/Yk/ControlPoint.cpp
+++ b/llvm/lib/Transforms/Yk/ControlPoint.cpp
@@ -134,9 +134,13 @@ public:
           DS_Warning));
       return false;
     }
-    assert(ControlPointCalls.size() == controlPointCount &&
-           "Unexpected number of control point calls");
 
+    if (ControlPointCalls.size() != controlPointCount) {
+      Context.emitError("Unexpected number of control point calls: " +
+                        Twine(ControlPointCalls.size()) +
+                        " expected: " + Twine(controlPointCount));
+      return false;
+    }
     unsigned CPStackMapID = 0;
     Function *NF = nullptr;
 


### PR DESCRIPTION
Ensure that calls in original functions are referencing only original functions.

I encountered this issue when I was building `yklua` with latest `yk` `YKB_TRACER=swt`.
The main issue here is with serialization in `YkIRWriter`, where we don't serialize cloned functions but we still might end up with original functions calling cloned functions.

Lua build error:
```shell
Function not found in function index map: __yk_clone_luaO_tostring
LLVM ERROR: Function not found in function index map
```
[source](https://github.com/ykjit/ykllvm/blob/main/llvm/lib/YkIR/YkIRWriter.cpp#L377)