### PR TITLE
More accurate live variables at the control point.

### DIFF
--- a/llvm/lib/Transforms/Yk/ControlPoint.cpp
+++ b/llvm/lib/Transforms/Yk/ControlPoint.cpp
@@ -193,7 +193,8 @@ public:
 
       // Get live variables.
       LivenessAnalysis LA(Caller);
-      auto Lives = LA.getLiveVarsBefore(OldCtrlPointCall);
+      auto Lives =
+          LA.getLiveVarsBefore(OldCtrlPointCall->getNextNonDebugInstruction());
 
       Value *SMID = ConstantInt::get(Type::getInt64Ty(Context), CPStackMapID);
       Value *Shadow = ConstantInt::get(Type::getInt32Ty(Context), CPShadow);


### PR DESCRIPTION
Variables that die immediately after the control point are not live and thus don't need to be tracked and passed into traces. This reduces the number of live variables at the control point by one in some tests.