### PR TITLE
Use shadowstack in SWT cloned module

### DIFF
--- a/llvm/include/llvm/Transforms/Yk/ModuleClone.h
+++ b/llvm/include/llvm/Transforms/Yk/ModuleClone.h
@@ -3,7 +3,8 @@
 
 #include "llvm/Pass.h"
 
-#define YK_CLONE_PREFIX "__yk_unopt_"
+#define YK_UNOPT_PREFIX "__yk_unopt_"
+#define YK_UNOPT_MAIN "__yk_unopt_main"
 #define YK_CLONE_MODULE_CP_COUNT 2
 
 namespace llvm {

--- a/llvm/include/llvm/Transforms/Yk/ShadowStack.h
+++ b/llvm/include/llvm/Transforms/Yk/ShadowStack.h
@@ -4,7 +4,7 @@
 #include "llvm/Pass.h"
 
 namespace llvm {
-ModulePass *createYkShadowStackPass();
+ModulePass *createYkShadowStackPass(uint64_t controlPointCount);
 } // namespace llvm
 
 #endif

--- a/llvm/lib/CodeGen/TargetPassConfig.cpp
+++ b/llvm/lib/CodeGen/TargetPassConfig.cpp
@@ -1162,7 +1162,7 @@ bool TargetPassConfig::addISelPasses() {
   }
 
   if (YkShadowStack) {
-    addPass(createYkShadowStackPass());
+    addPass(createYkShadowStackPass(numberOfControlPoints));
   }
   // We insert the yk control point pass as late as possible. It has to run
   // before instruction selection (or the machine IR won't reflect our

--- a/llvm/lib/Transforms/Yk/ModuleClone.cpp
+++ b/llvm/lib/Transforms/Yk/ModuleClone.cpp
@@ -79,7 +79,7 @@ struct YkModuleClone : public ModulePass {
         continue;
       }
       // Skip already cloned functions or functions with address taken.
-      if (F.hasAddressTaken() || F.getName().startswith(YK_CLONE_PREFIX)) {
+      if (F.hasAddressTaken() || F.getName().startswith(YK_UNOPT_PREFIX)) {
         continue;
       }
       ValueToValueMapTy VMap;
@@ -96,7 +96,7 @@ struct YkModuleClone : public ModulePass {
       }
       // Rename function
       auto originalName = F.getName().str();
-      auto cloneName = Twine(YK_CLONE_PREFIX) + originalName;
+      auto cloneName = Twine(YK_UNOPT_PREFIX) + originalName;
       ClonedFunc->setName(cloneName);
       ClonedFuncs[originalName] = ClonedFunc;
     }

--- a/llvm/lib/Transforms/Yk/ShadowStack.cpp
+++ b/llvm/lib/Transforms/Yk/ShadowStack.cpp
@@ -117,10 +117,16 @@ class YkShadowStack : public ModulePass {
   Type *Int8PtrTy = nullptr;
   Type *Int32Ty = nullptr;
   Type *PointerSizedIntTy = nullptr;
+  using AllocaVector = std::vector<std::pair<AllocaInst *, size_t>>;
+
+private:
+  uint64_t controlPointCount;
 
 public:
   static char ID;
-  YkShadowStack() : ModulePass(ID) {
+
+  YkShadowStack(uint64_t controlPointCount)
+      : ModulePass(ID), controlPointCount(controlPointCount) {
     initializeYkShadowStackPass(*PassRegistry::getPassRegistry());
   }
 
@@ -179,8 +185,7 @@ public:
 
   // Scan the function `F` for instructions of interest and compute the layout
   // of the shadow frame.
-  size_t analyseFunction(Function &F, DataLayout &DL,
-                         std::map<AllocaInst *, size_t> &Allocas,
+  size_t analyseFunction(Function &F, DataLayout &DL, AllocaVector &Allocas,
                          std::vector<ReturnInst *> &Rets) {
     size_t SFrameSize = 0;
     for (BasicBlock &BB : F) {
@@ -212,7 +217,7 @@ public:
           // space (to padding) by sorting them by size.
           size_t Align = AI->getAlign().value();
           SFrameSize = ((SFrameSize + (Align - 1)) / Align) * Align;
-          Allocas.insert({AI, SFrameSize});
+          Allocas.push_back({AI, SFrameSize});
           SFrameSize += AI->getAllocationSize(DL).value();
         } else if (ReturnInst *RI = dyn_cast<ReturnInst>(&I)) {
           Rets.push_back(RI);
@@ -249,15 +254,20 @@ public:
   }
 
   // Replace alloca instructions with shadow stack accesses.
-  void rewriteAllocas(DataLayout &DL, std::map<AllocaInst *, size_t> &Allocas,
-                      Value *SSPtr) {
+  // Returns a vector of the GEP instructions that replaced the original
+  // allocas.
+  std::vector<GetElementPtrInst *>
+  rewriteAllocas(DataLayout &DL, AllocaVector &Allocas, Value *SSPtr) {
+    std::vector<GetElementPtrInst *> Instructions;
     for (auto [AI, Off] : Allocas) {
       GetElementPtrInst *GEP = GetElementPtrInst::Create(
           Int8Ty, SSPtr, {ConstantInt::get(Int32Ty, Off)}, "", AI);
       AI->replaceAllUsesWith(GEP);
       AI->removeFromParent();
       AI->deleteValue();
+      Instructions.push_back(GEP);
     }
+    return Instructions;
   }
 
   /// At each place the function can return, insert IR to restore the shadow
@@ -268,6 +278,83 @@ public:
     for (ReturnInst *RI : Rets) {
       IRBuilder<> Builder(RI);
       Builder.CreateStore(InitSSPtr, SSGlobal);
+    }
+  }
+
+  // Handle `main` separatley, since it works slightly differently to other
+  // functions: it allocates the shadow stack
+  //
+  // For `__yk_unopt_main` we update the allocas while reusing the same shadow
+  // stack instance allocated by `main`.
+  //
+  // Note that since we assuming main() doesn't call main(), we can consider
+  // the shadow stack disused at the point main() returns. For this reason,
+  // there's no need to emit a shadow epilogue for main().
+  //
+  // YKFIXME: Investigate languages that don't have/use main as the first
+  // entry point.
+  void updateMainFunctions(DataLayout &DL, Module &M, GlobalVariable *SSGlobal,
+                           LLVMContext &Context) {
+    Function *Main = M.getFunction(MAIN);
+    if (Main == nullptr || Main->isDeclaration()) {
+      Context.emitError("Unable to add shadow stack: could not find definition "
+                        "of \"main\" function!");
+      return;
+    }
+
+    // Update the original main function.
+    AllocaVector MainAllocas;
+    std::vector<ReturnInst *> MainRets;
+    size_t SFrameSize = analyseFunction(*Main, DL, MainAllocas, MainRets);
+    CallInst *Malloc = insertMainPrologue(Main, SSGlobal, SFrameSize);
+    auto MainGEPs = rewriteAllocas(DL, MainAllocas, Malloc);
+
+    // If we have two control points, we need to update the cloned main
+    // function as well.
+    if (controlPointCount == 2) {
+      Function *UnoptMain = M.getFunction(YK_UNOPT_MAIN);
+      if (UnoptMain == nullptr || UnoptMain->isDeclaration()) {
+        Context.emitError(
+            "Unable to add shadow stack: could not find definition "
+            "of \"__yk_unopt_main\" function!");
+        return;
+      }
+
+      AllocaVector UnoptMainAllocas;
+      std::vector<ReturnInst *> UnoptMainRets;
+      size_t SFrameSizeUnopt =
+          analyseFunction(*UnoptMain, DL, UnoptMainAllocas, UnoptMainRets);
+
+      // Insert a load of SSGlobal at the beginning of UnoptMain.
+      BasicBlock &EntryBB = UnoptMain->getEntryBlock();
+      Instruction *FirstNonPHI = EntryBB.getFirstNonPHI();
+      IRBuilder<> Builder(FirstNonPHI);
+
+      // Load the current shadow stack pointer from the global variable.
+      LoadInst *LoadedSSPtr = Builder.CreateLoad(Int8PtrTy, SSGlobal);
+      // Assert that the allocas count match between opt/unopt main
+      assert(MainAllocas.size() == UnoptMainAllocas.size() &&
+             "Expected same number of allocas between opt/unopt main");
+
+      auto UnoptMainGEPs = rewriteAllocas(DL, UnoptMainAllocas, LoadedSSPtr);
+      // Validate that opt and unopt main have the same GEPs.
+      assert(MainGEPs.size() == UnoptMainGEPs.size() &&
+             "Expected same number of GEPs between opt/unopt main");
+      // Validate that each pair of GEPs has matching offsets and types
+      for (size_t i = 0; i < MainGEPs.size(); i++) {
+        GetElementPtrInst *OptGEP = MainGEPs[i];
+        GetElementPtrInst *UnoptGEP = UnoptMainGEPs[i];
+        // Check that the offset operands match
+        ConstantInt *OptOffset = cast<ConstantInt>(OptGEP->getOperand(1));
+        ConstantInt *UnoptOffset = cast<ConstantInt>(UnoptGEP->getOperand(1));
+        assert(OptOffset->getValue() == UnoptOffset->getValue() &&
+               "GEP offsets must match between opt/unopt main");
+
+        // Check that the resulting pointer types match
+        assert(OptGEP->getResultElementType() ==
+                   UnoptGEP->getResultElementType() &&
+               "GEP result types must match between opt/unopt main");
+      }
     }
   }
 
@@ -291,25 +378,7 @@ public:
     SSGlobal->setInitializer(
         ConstantPointerNull::get(cast<PointerType>(Int8PtrTy)));
 
-    // Handle main() separatley, since it works slightly differently to other
-    // functions: it allocates the shadow stack.
-    //
-    // Note that since we assuming main() doesn't call main(), we can consider
-    // the shadow stack disused at the point main() returns. For this reason,
-    // there's no need to emit a shadow epilogue for main().
-    //
-    // YKFIXME: Investigate languages that don't have/use main as the first
-    // entry point.
-    Function *Main = M.getFunction(MAIN);
-    if (Main == nullptr || Main->isDeclaration()) {
-      Context.emitError("Unable to add shadow stack: could not find definition "
-                        "of \"main\" function!");
-    }
-    std::map<AllocaInst *, size_t> MainAllocas;
-    std::vector<ReturnInst *> MainRets;
-    size_t SFrameSize = analyseFunction(*Main, DL, MainAllocas, MainRets);
-    CallInst *Malloc = insertMainPrologue(Main, SSGlobal, SFrameSize);
-    rewriteAllocas(DL, MainAllocas, Malloc);
+    updateMainFunctions(DL, M, SSGlobal, Context);
 
     // Instrument each remaining function with shadow stack code.
     for (Function &F : M) {
@@ -317,13 +386,12 @@ public:
         // skip declarations.
         continue;
       }
-
-      if (F.getName() == MAIN || F.getName().startswith(YK_CLONE_PREFIX)) {
-        // We've handled main already.
+      // skip already handled main and unopt functions
+      if (F.getName() == MAIN || F.getName() == YK_UNOPT_MAIN) {
         continue;
       }
 
-      std::map<AllocaInst *, size_t> Allocas;
+      AllocaVector Allocas;
       std::vector<ReturnInst *> Rets;
       size_t SFrameSize = analyseFunction(F, DL, Allocas, Rets);
       if (SFrameSize > 0) {
@@ -349,4 +417,6 @@ public:
 char YkShadowStack::ID = 0;
 INITIALIZE_PASS(YkShadowStack, DEBUG_TYPE, "yk shadowstack", false, false)
 
-ModulePass *llvm::createYkShadowStackPass() { return new YkShadowStack(); }
+ModulePass *llvm::createYkShadowStackPass(uint64_t controlPointCount) {
+  return new YkShadowStack(controlPointCount);
+}

--- a/llvm/lib/Transforms/Yk/StackMaps.cpp
+++ b/llvm/lib/Transforms/Yk/StackMaps.cpp
@@ -56,7 +56,7 @@ public:
     for (Function &F : M) {
       if (F.empty()) // skip declarations.
         continue;
-      if (F.getName().startswith(YK_CLONE_PREFIX)) // skip cloned functions
+      if (F.getName().startswith(YK_UNOPT_PREFIX)) // skip cloned functions
         continue;
 
       LivenessAnalysis LA(&F);

--- a/llvm/lib/YkIR/YkIRWriter.cpp
+++ b/llvm/lib/YkIR/YkIRWriter.cpp
@@ -1817,7 +1817,7 @@ public:
     int functionCount = 0;
     for (llvm::Function &F : M) {
       // Skip cloned functions
-      if (!StringRef(F.getName()).startswith(YK_CLONE_PREFIX)) {
+      if (!StringRef(F.getName()).startswith(YK_UNOPT_PREFIX)) {
         FunctionIndexMap[&F] = functionCount;
         functionCount++;
       }
@@ -1827,7 +1827,7 @@ public:
     // funcs:
     for (llvm::Function &F : M) {
       // Skip cloned functions
-      if (StringRef(F.getName()).startswith(YK_CLONE_PREFIX)) {
+      if (StringRef(F.getName()).startswith(YK_UNOPT_PREFIX)) {
         continue;
       }
       serialiseFunc(F);


### PR DESCRIPTION
The ShadowStack pass, which transforms allocas into shadow stack pointers, is currently ignoring all unoptimised functions ([code reference](https://github.com/ykjit/ykllvm/blob/main/llvm/lib/Transforms/Yk/ShadowStack.cpp#L321)). However, we require these functions to utilise shadow stack pointers, as tracing is performed within them.

Furthermore, the unoptimised main function must be adjusted to use the same shadow stack instance as the optimised main function. This adjustment is essential because the unoptimised and optimised main functions need to share variables stored on the stack, facilitating the transitions between the versions.

This pull request ensures that both the optimised and unoptimised main functions use the same shadow stack. There is no need to establish a mapping between the allocas of the two functions, as the ordering of allocas remains consistent by definition; the functions are direct copies of one another.

Note: once we have the control point transition implemented, we can remove the shadow stack pointers from the optimised functions completely.


Example of variables in `__yk_unopt_main` declared before this change:
```
define dso_local i32 @__yk_unopt_main(i32 noundef %0, ptr noundef %1) local_unnamed_addr #0 !dbg !84 {
  call void @__yk_trace_basicblock(i32 9, i32 0)
  %3 = alloca i32, align 4
  %4 = alloca i32, align 4
  %5 = alloca ptr, align 8
  %6 = alloca ptr, align 8
  %7 = alloca %struct.YkLocation, align 8
  %8 = alloca i32, align 4
  %9 = alloca i32, align 4
```
Variables in `__yk_unopt_main` declared after this change:
```
define dso_local i32 @__yk_unopt_main(i32 noundef %0, ptr noundef %1) local_unnamed_addr #0 !dbg !83 {
  call void @__yk_trace_basicblock(i32 9, i32 0)
  %3 = load ptr, ptr @shadowstack_0, align 8
  %4 = getelementptr i8, ptr %3, i32 0
  %5 = getelementptr i8, ptr %3, i32 4
  %6 = getelementptr i8, ptr %3, i32 8
  %7 = alloca ptr, align 8
  %8 = alloca %struct.YkLocation, align 8
  %9 = getelementptr i8, ptr %3, i32 16
  store i32 0,  %30) #6, !dbg !131, !srcloc !84
  br label %31, !dbg !132
```