### PR TITLE
Fix additional stackmap locations in loops.

### DIFF
--- a/llvm/test/CodeGen/X86/yk-stackmaps-extralocs-loop-fix.mir
+++ b/llvm/test/CodeGen/X86/yk-stackmaps-extralocs-loop-fix.mir
@@ -1,0 +1,63 @@
+# RUN: llc -mtriple=x86_64-- --yk-stackmap-add-locs %s -o - | FileCheck %s
+
+# Check that additional locations are only added to stackmaps if those
+# locations are valid on all paths this block is in. Here, for example, there's
+# an additional location `-8` for `$r13` in `bb.1`. However, `bb.1` is in a
+# loop which later overwrites `$r13`. On the next iteration the additional
+# location `-8` would no longer be valid for `$r13` and thus needs to be
+# removed.
+
+# CHECK-LABEL: __LLVM_StackMaps:
+# CHECK-LABEL: .quad 9
+# CHECK-LABEL: .short 8
+# CHECK-NEXT: .short 13
+# CHECK-NEXT: .short 0
+# CHECK-NEXT: .short 0
+# CHECK-NEXT: .long 0
+
+# Check that additional locations that are valid on all paths are still being
+# encoded.
+
+# CHECK-LABEL: .short 14
+# CHECK-NEXT: .short 0
+# CHECK-NEXT: .short 1
+# CHECK-NEXT: .short -24
+# CHECK-NEXT: .long 0
+---
+name: main
+tracksRegLiveness: true
+frameInfo:
+  hasStackMap:     true
+  stackSize:       24
+stack:
+  - { id: 0, type: spill-slot, offset: -8, size: 8, alignment: 8 }
+  - { id: 1, type: spill-slot, offset: -16, size: 8, alignment: 8 }
+  - { id: 2, type: spill-slot, offset: -24, size: 8, alignment: 8 }
+body: |
+  bb.0:
+    successors: %bb.1
+    $rbp = frame-setup MOV64rr $rsp
+    $r13 = MOV64rm $rbp, 1, $noreg, -8, $noreg :: (load (s64) from %stack.0)
+    $r14 = MOV64rm $rbp, 1, $noreg, -24, $noreg :: (load (s64) from %stack.0)
+    JMP_1 %bb.1
+
+  bb.1:
+  ; predecessors: %bb.0, %bb.2
+    liveins: $r13, $r14
+    STACKMAP 9, 0, $r13, $r14, 3
+    $r14 = MOV64rr $r13
+    JMP_1 %bb.2
+
+  bb.2:
+  ; predecessors: %bb.1
+    liveins: $r13, $r14
+    $r13 = MOV64rm $rbp, 1, $noreg, -16, $noreg :: (load (s64) from %stack.1)
+    $r14 = MOV64rm $rbp, 1, $noreg, -24, $noreg :: (load (s64) from %stack.0)
+    renamable $rax = MOV64rr $r13, implicit-def $rax
+    CMP32ri renamable $eax, 50, implicit-def $eflags
+    JCC_1 %bb.1, 2, implicit $eflags
+
+  bb.3:
+  ; predecessors: %bb.2
+    liveins: $rax
+    RET64 $rax

--- a/llvm/test/CodeGen/X86/yk-stackmaps-extrareg.ll
+++ b/llvm/test/CodeGen/X86/yk-stackmaps-extrareg.ll
@@ -2,19 +2,15 @@
 ; RUN: llc --yk-stackmap-spillreloads-fix --yk-stackmap-add-locs < %s | FileCheck %s
 
 ; CHECK-LABEL: __LLVM_StackMaps:
-; CHECK-LABEL: .long   -56
-; CHECK-NEXT: .byte 1
-; CHECK-NEXT: .byte 1
-; CHECK-NEXT: .byte 0
-; CHECK-NEXT: .short 8
+; CHECK-LABEL: .long   -184
 ; NOTE: Actual tracked register
-; CHECK-NEXT: .short 13
+; CHECK-LABEL: .short  12
 ; NOTE: Reserved
 ; CHECK-NEXT: .short 0
 ; NOTE: Number of extra locations.
 ; CHECK-NEXT: .short 1
 ; NOTE: Stack offset this value is stored in.
-; CHECK-NEXT: .short -80
+; CHECK-NEXT: .short -64
 
 source_filename = "ld-temp.o"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"


### PR DESCRIPTION
Our pass which adds additional locations to stackmaps doesn't work correctly in the presence of loops. Here's and example:

```
bb0:
  mov rax, [rbp-8]
  br bb1

bb1:
  STACKMAP [rax]
  br bb2

bb2:
  mov rax, [rbp-16]
  br bb1
```

Here, the first time we enter `bb1` the variable that's stored in `rax` has an extra location `rbp-8`. However, when we enter `bb1` again via `bb2`, the extra location has now changed to `rbp-16`.

Previously, we would process each block only once, and thus, for the above example, encode `rbp-8` as an additional location. However, on the second iteration of the loop, this is no longer correct, so writing to `rbp-8` during deoptimisation can lead to bugs.

In this commit we fix the algorithm but taking loops into account and only encode additional locations into stackmaps that are valid in all iterations. We do this by following the control flow and processing blocks potentially multiple times, and removing additional locations that aren't valid on all paths leading to this block (in more technical terms we take the intersection of the previous and current additional locations on each iteration and re-apply it to the block).