### PR TITLE
Implement compiler support for the idempotent hint.

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -4241,6 +4241,13 @@ def YkOutline : InheritableAttr {
   let SimpleHandler = 1;
 }
 
+def YkIdempotent : InheritableAttr {
+  let Spellings = [GCC<"yk_idempotent">, Declspec<"yk_idempotent">];
+  let Subjects = SubjectList<[Function]>;
+  let Documentation = [YkIdempotentDocs];
+  let SimpleHandler = 1;
+}
+
 def YkUnrollSafe : InheritableAttr {
   let Spellings = [GCC<"yk_unroll_safe">, Declspec<"yk_unroll_safe">];
   let Subjects = SubjectList<[Function]>;

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -7191,6 +7191,11 @@ def YkOutlineDocs : Documentation {
   }];
 }
 
+def YkIdempotentDocs : Documentation {
+  let Category = DocCatFunction;
+  let Content = [{tells the yk trace optimiser that this function is idempotent}];
+}
+
 def YkUnrollSafeDocs : Documentation {
   let Category = DocCatFunction;
   let Content = [{

--- a/clang/test/Misc/pragma-attribute-supported-attributes-list.test
+++ b/clang/test/Misc/pragma-attribute-supported-attributes-list.test
@@ -204,6 +204,7 @@
 // CHECK-NEXT: WorkGroupSizeHint (SubjectMatchRule_function)
 // CHECK-NEXT: XRayInstrument (SubjectMatchRule_function, SubjectMatchRule_objc_method)
 // CHECK-NEXT: XRayLogArgs (SubjectMatchRule_function, SubjectMatchRule_objc_method)
+// CHECK-NEXT: YkIdempotent (SubjectMatchRule_function)
 // CHECK-NEXT: YkOutline (SubjectMatchRule_function)
 // CHECK-NEXT: YkUnrollSafe (SubjectMatchRule_function)
 // CHECK-NEXT: ZeroCallUsedRegs (SubjectMatchRule_function)

--- a/llvm/include/llvm/Support/Yk.h
+++ b/llvm/include/llvm/Support/Yk.h
@@ -10,5 +10,6 @@ void initYkOptions(void);
 extern bool YkOptNoneAfterIRPasses;
 extern bool YkDontOptFuncABI;
 extern bool YkPatchCtrlPoint;
+extern bool YkPatchIdempotent;
 
 #endif

--- a/llvm/include/llvm/Transforms/Yk/Idempotent.h
+++ b/llvm/include/llvm/Transforms/Yk/Idempotent.h
@@ -1,0 +1,13 @@
+#ifndef LLVM_TRANSFORMS_YK_IDEMPOTENT_H
+#define LLVM_TRANSFORMS_YK_IDEMPOTENT_H
+
+#include "llvm/Pass.h"
+
+#define YK_IDEMPOTENT_RECORDER_FUNC "__yk_idempotent_promote_usize"
+#define YK_IDEMPOTENT_FNATTR "yk_idempotent"
+
+namespace llvm {
+ModulePass *createYkIdempotentPass();
+} // namespace llvm
+
+#endif

--- a/llvm/include/llvm/YkIR/YkIRWriter.h
+++ b/llvm/include/llvm/YkIR/YkIRWriter.h
@@ -5,6 +5,8 @@
 #include "llvm/MC/MCContext.h"
 #include "llvm/MC/MCStreamer.h"
 
+#define YK_OUTLINE_FNATTR "yk_outline"
+
 namespace llvm {
   void embedYkIR(MCContext &Ctx, MCStreamer &OutStreamer, Module &M);
 } // namespace llvm

--- a/llvm/lib/CodeGen/TargetPassConfig.cpp
+++ b/llvm/lib/CodeGen/TargetPassConfig.cpp
@@ -51,6 +51,7 @@
 #include "llvm/Transforms/Utils.h"
 #include "llvm/Transforms/Yk/BlockDisambiguate.h"
 #include "llvm/Transforms/Yk/ControlPoint.h"
+#include "llvm/Transforms/Yk/Idempotent.h"
 #include "llvm/Transforms/Yk/Linkage.h"
 #include "llvm/Transforms/Yk/ShadowStack.h"
 #include "llvm/Transforms/Yk/SplitBlocksAfterCalls.h"
@@ -1181,6 +1182,10 @@ bool TargetPassConfig::addISelPasses() {
 
   if (YkLinkage) {
     addPass(createYkLinkagePass());
+  }
+
+  if (YkPatchIdempotent) {
+    addPass(createYkIdempotentPass());
   }
 
   if (YkSplitBlocksAfterCalls) {

--- a/llvm/lib/Support/Yk.cpp
+++ b/llvm/lib/Support/Yk.cpp
@@ -123,6 +123,18 @@ struct CreateYkPatchCtrlPointParser {
 } // namespace
 static ManagedStatic<cl::opt<bool, true>, CreateYkPatchCtrlPointParser> YkPatchCtrlPointParser;
 
+bool YkPatchIdempotent;
+namespace {
+struct CreateYkPatchIdempotentParser {
+  static void *call() {
+    return new cl::opt<bool, true>(
+        "yk-patch-idempotent",
+        cl::desc("Patch in idempotent function recorders"),
+        cl::NotHidden, cl::location(YkPatchIdempotent));
+  }
+};
+} // namespace
+static ManagedStatic<cl::opt<bool, true>, CreateYkPatchIdempotentParser> YkPatchIdempotentParser;
 
 void llvm::initYkOptions() {
   *YkExtendedLLVMBBAddrMapSectionParser;
@@ -133,4 +145,5 @@ void llvm::initYkOptions() {
   *YkEmbedIRParser;
   *YkDontOptFuncABIParser;
   *YkPatchCtrlPointParser;
+  *YkPatchIdempotentParser;
 }

--- a/llvm/lib/Transforms/Yk/CMakeLists.txt
+++ b/llvm/lib/Transforms/Yk/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_llvm_component_library(LLVMYkPasses
   BlockDisambiguate.cpp
   ControlPoint.cpp
+  Idempotent.cpp
   Linkage.cpp
   LivenessAnalysis.cpp
   StackMaps.cpp

--- a/llvm/lib/Transforms/Yk/Idempotent.cpp
+++ b/llvm/lib/Transforms/Yk/Idempotent.cpp
@@ -1,0 +1,99 @@
+//===- Idempotent.cpp - Capture return values of idempotent functions --===//
+//
+// This pass finds call sites to functions marked with the `yk_idempotent`
+// attribute and injects IR to record their return values when tracing is
+// enabled. If the JIT can later prove the arguments to the idempotent function
+// to be constant, then the entire call can be removed and the return value can
+// be replaced with the value that was recorded at trace time.
+
+#include "llvm/Transforms/Yk/Idempotent.h"
+#include "llvm/IR/BasicBlock.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/Verifier.h"
+#include "llvm/InitializePasses.h"
+#include "llvm/Pass.h"
+
+#define DEBUG_TYPE "yk-stackmaps"
+
+using namespace llvm;
+
+namespace llvm {
+void initializeYkIdempotentPass(PassRegistry &);
+} // namespace llvm
+
+namespace {
+class YkIdempotent : public ModulePass {
+public:
+  static char ID;
+  YkIdempotent() : ModulePass(ID) {
+    initializeYkIdempotentPass(*PassRegistry::getPassRegistry());
+  }
+
+  bool insertCalls(Module &M) {
+    LLVMContext &Context = M.getContext();
+
+    // First declare the recorder function. The JIT runtime will provide
+    // the definition when the module is linked.
+    //
+    // FIXME: This only works for pointer-sized integers for now. Other types
+    // can be added later.
+    DataLayout DL(&M);
+    Type *PtrSizedIntTy = DL.getIntPtrType(Context);
+    FunctionType *RecFType =
+        FunctionType::get(PtrSizedIntTy, {PtrSizedIntTy}, false);
+    Function *RecF = Function::Create(RecFType, GlobalVariable::ExternalLinkage,
+                                      YK_IDEMPOTENT_RECORDER_FUNC, M);
+
+    // Search the module for functions marked idempotent and insert a call to
+    // the recorder at all returns within the function.
+    IRBuilder<> Builder(Context);
+    for (Function &F : M) {
+      for (BasicBlock &BB : F) {
+        for (Instruction &I : BB) {
+          if (CallBase *CI = dyn_cast<CallBase>(&I)) {
+            // We only support direct calls for now.
+            if (CI->isIndirectCall()) {
+              continue;
+            }
+            Function *CF = CI->getCalledFunction();
+            if (!CF || !CF->hasFnAttribute(YK_IDEMPOTENT_FNATTR)) {
+              continue;
+            }
+            if (CF->getFunctionType()->getReturnType() != PtrSizedIntTy) {
+              Context.emitError(
+                  "unimplemented idempotent promote type. Only pointer-sized "
+                  "integers are supported.");
+              return false;
+            }
+
+            // Call the recorder after the call to the idempotent function.
+            Builder.SetInsertPoint(CI->getNextNode());
+            CallInst *RecCall = Builder.CreateCall(RecFType, RecF, {CI});
+            // Rewrite all future uses of the return value of the idempotent
+            // function to the return value of the call to the recorder.
+            CI->replaceUsesWithIf(RecCall, [RecCall](Use &U) -> bool {
+              return U.getUser() != RecCall;
+            });
+          }
+        }
+      }
+    }
+    return true;
+  }
+
+  bool runOnModule(Module &M) override { return insertCalls(M); }
+};
+} // namespace
+
+char YkIdempotent::ID = 0;
+INITIALIZE_PASS(YkIdempotent, DEBUG_TYPE, "yk idempotent", false, false)
+
+/**
+ * @brief Creates a new YkIdempotent pass.
+ *
+ * @return ModulePass* A pointer to the newly created YkIdempotent pass.
+ */
+ModulePass *llvm::createYkIdempotentPass() { return new YkIdempotent(); }


### PR DESCRIPTION
This does a few things:

 - adds a `yk_idempotent` function attribute to clang and llvm.

 - adds an LLVM pass that records the runtime return values of functions with the annotation.

 - adds the `IdempotentPromote` bytecode for the calls to the recorder function (so the JIT can easily identify them later).

For now we only support idempotent functions that return a pointer sized integer.

Required by https://github.com/ykjit/yk/pull/1633