### PR TITLE
Add additional location support for patchpoint instructions.

### DIFF
--- a/llvm/include/llvm/CodeGen/StackMaps.h
+++ b/llvm/include/llvm/CodeGen/StackMaps.h
@@ -297,7 +297,7 @@ public:
                       std::map<Register, std::set<int64_t>> SpillsOffsets = {});
 
   /// Generate a stackmap record for a patchpoint instruction.
-  void recordPatchPoint(const MCSymbol &L, const MachineInstr &MI);
+  void recordPatchPoint(const MCSymbol &L, const MachineInstr &MI, std::map<Register, std::set<int64_t>> SpillOffsets = {});
 
   /// Generate a stackmap record for a statepoint instruction.
   void recordStatepoint(const MCSymbol &L, const MachineInstr &MI);

--- a/llvm/lib/CodeGen/StackMaps.cpp
+++ b/llvm/lib/CodeGen/StackMaps.cpp
@@ -673,7 +673,9 @@ void StackMaps::recordStackMap(const MCSymbol &L,
                       MI.operands_end(), SpillOffsets);
 }
 
-void StackMaps::recordPatchPoint(const MCSymbol &L, const MachineInstr &MI) {
+void StackMaps::recordPatchPoint(
+    const MCSymbol &L, const MachineInstr &MI,
+    std::map<Register, std::set<int64_t>> SpillOffsets) {
   assert(MI.getOpcode() == TargetOpcode::PATCHPOINT && "expected patchpoint");
 
   PatchPointOpers opers(&MI);

--- a/llvm/lib/Target/X86/X86AsmPrinter.cpp
+++ b/llvm/lib/Target/X86/X86AsmPrinter.cpp
@@ -125,21 +125,8 @@ void processInstructions(
   for (const MachineInstr &Instr : MBB->instrs()) {
     // At each stackmap call, save the current mapping so it can later be
     // encoded in the stackmap when it is lowered.
-    if (Instr.getOpcode() == TargetOpcode::STACKMAP) {
+    if (Instr.getOpcode() == TargetOpcode::STACKMAP || Instr.getOpcode() == TargetOpcode::PATCHPOINT) {
       StackmapSpillMaps[&Instr] = SpillMap;
-      for (const MachineOperand MO : Instr.uses()) {
-        if (MO.isReg() && MO.isKill()) {
-          auto DwReg = getDwarfRegNum(MO.getReg(), TRI);
-          killRegister(DwReg, SpillMap);
-        }
-      }
-      continue;
-    }
-
-    // Because a patchpoint already captures the live values at the exact
-    // moment we desire, there's no need to compute a spillmap for them nor do
-    // we have to "patch them up". We can just skip them.
-    if (Instr.getOpcode() == TargetOpcode::PATCHPOINT) {
       for (const MachineOperand MO : Instr.uses()) {
         if (MO.isReg() && MO.isKill()) {
           auto DwReg = getDwarfRegNum(MO.getReg(), TRI);

--- a/llvm/lib/Target/X86/X86MCInstLower.cpp
+++ b/llvm/lib/Target/X86/X86MCInstLower.cpp
@@ -1041,7 +1041,7 @@ void X86AsmPrinter::LowerPATCHPOINT(const MachineInstr &MI,
   auto &Ctx = OutStreamer->getContext();
   MCSymbol *MILabel = Ctx.createTempSymbol();
   OutStreamer->emitLabel(MILabel);
-  SM.recordPatchPoint(*MILabel, MI);
+  SM.recordPatchPoint(*MILabel, MI, StackmapSpillMaps[&MI]);
 
   PatchPointOpers opers(&MI);
   unsigned ScratchIdx = opers.getNextScratchIdx();


### PR DESCRIPTION
Extend the stackmap and patchpoint to track spill offsets for patchpoint instructions. This will allow us to get additional location data for control point live variables.