### PR TITLE
Rewrite indirect locations to register locations if they alias.

### DIFF
--- a/llvm/lib/CodeGen/StackMaps.cpp
+++ b/llvm/lib/CodeGen/StackMaps.cpp
@@ -251,6 +251,20 @@ StackMaps::parseOperand(MachineInstr::const_mop_iterator MOI,
       assert(Size > 0 && "Need a valid size for indirect memory locations.");
       Register Reg = (++MOI)->getReg();
       int64_t Imm = (++MOI)->getImm();
+      // Check if this indirect location aliases with a register. If so track
+      // the register instead alongside any extra locations attached to that
+      // register (by definition this indirect will be included in those extra
+      // locations).
+      for (auto [TrackReg, Extras]: SpillOffsets) {
+        for (auto E : Extras) {
+          if (E == Imm) {
+            const TargetRegisterClass *RC = TRI->getMinimalPhysRegClass(Reg);
+            Locs.emplace_back(Location::Register, TRI->getSpillSize(*RC), TrackReg,
+                              0, Extras);
+            return ++MOI;
+          }
+        }
+      }
       Locs.emplace_back(StackMaps::Location::Indirect, Size,
                         getDwarfRegNum(Reg, TRI), Imm);
       break;


### PR DESCRIPTION
When a register and an indirect location alias, we attach any extra locations to the register so that they are written to during deopt. This is based on the assumption that stackmaps will always prioritise tracking the register. There was no reason for us to assume this is always the case, and in fact we have now found a bug where the indirect location is tracked instead.

This commit fixes this issue, by checking during stackmap generation if a tracked indirect aliases with a register. If that is the case we emit the register (including the extra locations) into the stackmap in place of the indirect.