### PR TITLE
Don't insert stackmaps into `yk_outline` functions.

### DIFF
--- a/clang/test/Yk/idempotent_inlined_promotions.c
+++ b/clang/test/Yk/idempotent_inlined_promotions.c
@@ -1,0 +1,16 @@
+// Checks the compiler borks if a __yk_promote_* gets inlined into a
+// yk_idempotent function.
+//
+// RUN: not %clang -O2 -mllvm --yk-embed-ir -mllvm --yk-insert-stackmaps %s 2>&1 | FileCheck %s
+
+void *__yk_promote_ptr(void *);
+
+void g(void *p) {
+  __yk_promote_ptr(p);
+}
+
+// CHECK: error: promotion detected in yk_outline annotated function 'main'
+__attribute__((yk_idempotent))
+int main(int argc, char **argv) {
+  g(argv);
+}

--- a/clang/test/Yk/outline_inlined_promotions.c
+++ b/clang/test/Yk/outline_inlined_promotions.c
@@ -1,0 +1,16 @@
+// Checks the compiler borks if a __yk_promote_* gets inlined into a
+// yk_outline function.
+//
+// RUN: not %clang -O2 -mllvm --yk-embed-ir -mllvm --yk-insert-stackmaps %s 2>&1 | FileCheck %s
+
+void *__yk_promote_ptr(void *);
+
+void g(void *p) {
+  __yk_promote_ptr(p);
+}
+
+// CHECK: error: promotion detected in yk_outline annotated function 'main'
+__attribute__((yk_outline))
+int main(int argc, char **argv) {
+  g(argv);
+}

--- a/llvm/include/llvm/Transforms/Yk/ControlPoint.h
+++ b/llvm/include/llvm/Transforms/Yk/ControlPoint.h
@@ -19,6 +19,7 @@
 
 namespace llvm {
 ModulePass *createYkControlPointPass(uint64_t controlPointCount);
+bool containsControlPoint(llvm::Function &F);
 } // namespace llvm
 
 #endif

--- a/llvm/lib/Transforms/Yk/ControlPoint.cpp
+++ b/llvm/lib/Transforms/Yk/ControlPoint.cpp
@@ -238,3 +238,18 @@ INITIALIZE_PASS(YkControlPoint, DEBUG_TYPE, "yk control point", false, false)
 ModulePass *llvm::createYkControlPointPass(uint64_t controlPointCount) {
   return new YkControlPoint(controlPointCount);
 }
+
+// Returns true iff the function contains a (patched) control point.
+bool llvm::containsControlPoint(llvm::Function &F) {
+  for (BasicBlock &BB : F) {
+    for (Instruction &I : BB) {
+      if (CallBase *CI = dyn_cast<CallBase>(&I)) {
+        Function *CF = CI->getCalledFunction();
+        if ((CF != nullptr) && (CF->getName() == CP_PPNAME)) {
+          return true;
+        }
+      }
+    }
+  }
+  return false;
+}

--- a/llvm/lib/Transforms/Yk/Idempotent.cpp
+++ b/llvm/lib/Transforms/Yk/Idempotent.cpp
@@ -15,6 +15,8 @@
 #include "llvm/IR/Verifier.h"
 #include "llvm/InitializePasses.h"
 #include "llvm/Pass.h"
+#include "llvm/Transforms/Yk/ControlPoint.h"
+#include "llvm/YkIR/YkIRWriter.h"
 
 #define DEBUG_TYPE "yk-stackmaps"
 
@@ -73,6 +75,9 @@ public:
     // the recorder at all returns within the function.
     IRBuilder<> Builder(Context);
     for (Function &F : M) {
+      if ((F.hasFnAttribute(YK_OUTLINE_FNATTR)) && (!containsControlPoint(F))) {
+        continue;
+      }
       for (BasicBlock &BB : F) {
         for (Instruction &I : BB) {
           if (CallBase *CI = dyn_cast<CallBase>(&I)) {

--- a/llvm/lib/Transforms/Yk/StackMaps.cpp
+++ b/llvm/lib/Transforms/Yk/StackMaps.cpp
@@ -19,6 +19,7 @@
 #include "llvm/Transforms/Yk/ControlPoint.h"
 #include "llvm/Transforms/Yk/LivenessAnalysis.h"
 #include "llvm/Transforms/Yk/ModuleClone.h"
+#include "llvm/YkIR/YkIRWriter.h"
 #include <map>
 
 #define DEBUG_TYPE "yk-stackmaps"
@@ -58,6 +59,9 @@ public:
         continue;
       if (F.getName().startswith(YK_UNOPT_PREFIX)) // skip cloned functions
         continue;
+      if ((F.hasFnAttribute(YK_OUTLINE_FNATTR)) && (!containsControlPoint(F))) {
+        continue;
+      }
 
       LivenessAnalysis LA(&F);
       for (BasicBlock &BB : F) {

--- a/llvm/lib/YkIR/CMakeLists.txt
+++ b/llvm/lib/YkIR/CMakeLists.txt
@@ -3,6 +3,7 @@ add_llvm_component_library(LLVMYkIR
 
   LINK_COMPONENTS
   Core
+  YkPasses
   MC
   Support
   )

--- a/llvm/lib/YkIR/YkIRWriter.cpp
+++ b/llvm/lib/YkIR/YkIRWriter.cpp
@@ -1675,6 +1675,18 @@ private:
     // flags:
     serialiseFuncFlags(F);
 
+    // idempotent functions must have been marked yk_outline.
+    //
+    // The language frontend *must* do this, but we check anyway, especially
+    // since we often directly compile ll files for testing.
+    if ((F.hasFnAttribute(YK_IDEMPOTENT_FNATTR)) &&
+        (!F.hasFnAttribute(YK_OUTLINE_FNATTR))) {
+      M.getContext().emitError(Twine("idempotent function ") + F.getName() +
+                               " must also be annotated " + YK_OUTLINE_FNATTR +
+                               "\n");
+      return;
+    }
+
     if ((!F.hasFnAttribute(YK_OUTLINE_FNATTR)) || (containsControlPoint(F))) {
       // Emit a function *definition*.
       // num_blocks:

--- a/llvm/lib/YkIR/YkIRWriter.cpp
+++ b/llvm/lib/YkIR/YkIRWriter.cpp
@@ -1640,6 +1640,33 @@ private:
     OutStreamer.emitInt8(Flags);
   }
 
+  // Check if the user did anything invalid in a yk_outline function.
+  void checkBadYkOutline(Function &F) {
+    for (BasicBlock &BB : F) {
+      for (Instruction &I : BB) {
+        if (CallBase *CI = dyn_cast<CallBase>(&I)) {
+          Function *CF = CI->getCalledFunction();
+          if (CF != nullptr) {
+            if (CF->getName().starts_with(YK_PROMOTE_PREFIX)) {
+              // You can't use yk_promote() in an yk_outline function, as we
+              // won't have any IR for the function and thus won't be able to
+              // "skip over" those promotions in the trace builder.
+              F.getContext().emitError(
+                  Twine("promotion detected in ") + YK_OUTLINE_FNATTR +
+                  " annotated function '" + F.getName() + "'\n");
+            }
+            if (CF->getName() == YK_DEBUG_STR) {
+              // Same for debug strings. How would the trace builder skip them?
+              F.getContext().emitError(Twine(YK_DEBUG_STR) +
+                                       "() detected in function '" +
+                                       F.getName() + "'\n");
+            }
+          }
+        }
+      }
+    }
+  }
+
   void serialiseFunc(llvm::Function &F) {
     // name:
     serialiseString(F.getName());
@@ -1647,16 +1674,25 @@ private:
     OutStreamer.emitSizeT(typeIndex(F.getFunctionType()));
     // flags:
     serialiseFuncFlags(F);
-    // num_blocks:
-    OutStreamer.emitSizeT(F.size());
-    // blocks:
-    unsigned BBIdx = 0;
-    FuncLowerCtxt FLCtxt;
-    std::vector<Argument> V;
-    for (BasicBlock &BB : F) {
-      serialiseBlock(BB, FLCtxt, BBIdx, F);
+
+    if ((!F.hasFnAttribute(YK_OUTLINE_FNATTR)) || (containsControlPoint(F))) {
+      // Emit a function *definition*.
+      // num_blocks:
+      OutStreamer.emitSizeT(F.size());
+      // blocks:
+      unsigned BBIdx = 0;
+      FuncLowerCtxt FLCtxt;
+      std::vector<Argument> V;
+      for (BasicBlock &BB : F) {
+        serialiseBlock(BB, FLCtxt, BBIdx, F);
+      }
+      FLCtxt.patchUpInstIdxs(OutStreamer);
+    } else {
+      checkBadYkOutline(F);
+      // Emit a function *declaration*.
+      // num_blocks:
+      OutStreamer.emitSizeT(0);
     }
-    FLCtxt.patchUpInstIdxs(OutStreamer);
   }
 
   void serialiseFunctionType(FunctionType *Ty) {

--- a/llvm/test/YkIR/yk_debug_str_in_yk_outline.ll
+++ b/llvm/test/YkIR/yk_debug_str_in_yk_outline.ll
@@ -1,0 +1,11 @@
+; Checks the compiler borks if there's a yk_debug_str in a yk_outline function.
+;
+; RUN: not llc --yk-embed-ir < %s 2>&1 | FileCheck %s
+
+declare void @yk_debug_str(ptr)
+
+; CHECK: error: yk_debug_str() detected in function 'f'
+define void @f(ptr %p) "yk_outline" {
+    call void @yk_debug_str(ptr %p) ; invalid!
+	ret void
+}

--- a/llvm/test/YkIR/yk_idempotent_not_ykoutline.ll
+++ b/llvm/test/YkIR/yk_idempotent_not_ykoutline.ll
@@ -1,0 +1,12 @@
+; Checks the compiler borks if there's a __yk_promote_* in a yk_outline
+; function.
+;
+; RUN: not llc --yk-embed-ir < %s 2>&1 | FileCheck %s
+
+declare ptr @__yk_promote_ptr(ptr)
+
+; CHECK: error: idempotent function f must also be annotated yk_outline
+define void @f(ptr %p) "yk_idempotent" {
+    call ptr @__yk_promote_ptr(ptr %p) ; invalid!
+	ret void
+}

--- a/llvm/test/YkIR/yk_promote_in_yk_outline.ll
+++ b/llvm/test/YkIR/yk_promote_in_yk_outline.ll
@@ -1,0 +1,12 @@
+; Checks the compiler borks if there's a __yk_promote_* in a yk_outline
+; function.
+;
+; RUN: not llc --yk-embed-ir < %s 2>&1 | FileCheck %s
+
+declare ptr @__yk_promote_ptr(ptr)
+
+; CHECK: error: promotion detected in yk_outline annotated function 'f'
+define void @f(ptr %p) "yk_outline" {
+    call ptr @__yk_promote_ptr(ptr %p) ; invalid!
+	ret void
+}


### PR DESCRIPTION
A recent discussion brought to light the fact that there's no point in emitting stackmaps into functions that are marked `yk_outline`. By inserting stackmaps there, we pay a runtime cost (blocking AOT optimisations) for no real reason.

One way of not having stackmaps in yk_outline functions, would be to make all AOT IR fields for safepoints (in branch and call instructions) optional, and then in yk_outline functions we simply insert a None.

This strategy, however, requires changes reaching down the pipeline and the additional `Option`s would bloat the AOT IR since typically there are lots of safepoints.

What this change does instead is to not emit IR for functions annotated `yk_outline`. Instead we emit only a function declaration. This way, no changes are required to the structure of the IR.

There is a knock on effect though: if we have no IR for a function, we lose the ability, during outlining, to "skip over" any promotions, debug strings, or idempotent promotes that that function may inject into the trace.

To fix this we:
 - Prohibit the user from inserting yk_promote/yk_debug_str in any function marked `yk_outline`. This now results in a compiler error at AOT compile-time.
 - Turn off the automated ykllvm pass that inserts idempotent promotions for functions marked `yk_outline`.

Note that functions containing a control point are special exemptions. Although such functions get marked `yk_outline` because they contain a loop, by their very nature, we do trace them, and thus we must include stackmaps.

Benchmarking suggests some benchmarks will speed up. CD should be about 2x as fast.