### PR TITLE
Disable block splitting for yk_outline functions.

### DIFF
--- a/llvm/include/llvm/Transforms/Yk/ControlPoint.h
+++ b/llvm/include/llvm/Transforms/Yk/ControlPoint.h
@@ -19,6 +19,7 @@
 
 namespace llvm {
 ModulePass *createYkControlPointPass(uint64_t controlPointCount);
+bool containsControlPoint(llvm::Function &F);
 } // namespace llvm
 
 #endif

--- a/llvm/lib/Transforms/Yk/ControlPoint.cpp
+++ b/llvm/lib/Transforms/Yk/ControlPoint.cpp
@@ -238,3 +238,18 @@ INITIALIZE_PASS(YkControlPoint, DEBUG_TYPE, "yk control point", false, false)
 ModulePass *llvm::createYkControlPointPass(uint64_t controlPointCount) {
   return new YkControlPoint(controlPointCount);
 }
+
+// Returns true iff the function contains a (patched) control point.
+bool llvm::containsControlPoint(llvm::Function &F) {
+  for (BasicBlock &BB : F) {
+    for (Instruction &I : BB) {
+      if (CallBase *CI = dyn_cast<CallBase>(&I)) {
+        Function *CF = CI->getCalledFunction();
+        if ((CF != nullptr) && (CF->getName() == CP_PPNAME)) {
+          return true;
+        }
+      }
+    }
+  }
+  return false;
+}

--- a/llvm/lib/Transforms/Yk/SplitBlocksAfterCalls.cpp
+++ b/llvm/lib/Transforms/Yk/SplitBlocksAfterCalls.cpp
@@ -14,7 +14,9 @@
 #include "llvm/IR/Verifier.h"
 #include "llvm/InitializePasses.h"
 #include "llvm/Pass.h"
+#include "llvm/Transforms/Yk/ControlPoint.h"
 #include "llvm/Transforms/Yk/LivenessAnalysis.h"
+#include "llvm/YkIR/YkIRWriter.h"
 
 #include <map>
 
@@ -41,6 +43,12 @@ public:
     for (Function &F : M) {
       if (F.empty()) // skip declarations.
         continue;
+
+      // If we won't trace this function, no need for this transformation.
+      if ((F.hasFnAttribute(YK_OUTLINE_FNATTR)) && (!containsControlPoint(F))) {
+        continue;
+      }
+
       // As we will be modifying the blocks of this function inplace, we
       // require a work list to process all existing and newly inserted blocks
       // in order to not miss any.


### PR DESCRIPTION
Looks like it could make a small difference to performance.

e.g. CD benchmark
```
===> multitime results before
            Mean        Std.Dev.    Min         Median      Max
real        39.678      0.494       39.132      39.529      40.893
user        84.845      5.211       78.563      82.731      94.105
sys         109.256     20.494      84.483      103.518     142.538

===> multitime results after
            Mean        Std.Dev.    Min         Median      Max
real        38.924      0.329       38.337      39.031      39.443
user        87.130      3.802       78.461      87.670      91.602
sys         122.228     20.204      83.536      122.193     148.327
```