### PR TITLE
Allow fall-throughs in functions we won't trace.

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/CMakeLists.txt
+++ b/llvm/lib/CodeGen/SelectionDAG/CMakeLists.txt
@@ -38,4 +38,5 @@ add_llvm_component_library(LLVMSelectionDAG
   Target
   TargetParser
   TransformUtils
+  YkPasses
   )


### PR DESCRIPTION
Again, looks like it might make a small difference to performance:

```
===> multitime results before
1: /home/vext01/research/yklua/src/lua harness.lua cd 3 250
            Mean        Std.Dev.    Min         Median      Max
real        38.924      0.329       38.337      39.031      39.443
user        87.130      3.802       78.461      87.670      91.602
sys         122.228     20.204      83.536      122.193     148.327

===> multitime results afer
1: /home/vext01/research/yklua/src/lua harness.lua cd 3 250
            Mean        Std.Dev.    Min         Median      Max
real        37.889      0.526       37.069      37.905      38.601
user        82.886      3.734       78.679      82.111      89.148
sys         114.031     18.411      92.995      110.225     149.115
```