### PR TITLE
Improve containsControlPoint().

### DIFF
--- a/llvm/include/llvm/Transforms/Yk/ControlPoint.h
+++ b/llvm/include/llvm/Transforms/Yk/ControlPoint.h
@@ -17,6 +17,9 @@
 // The name of the patchpoint intrinsic we use for the control point.
 #define CP_PPNAME "llvm.experimental.patchpoint.void"
 
+// The operand index of a patchpoint's target operand.
+#define PP_TARGET_OPND_IDX 2
+
 namespace llvm {
 ModulePass *createYkControlPointPass(uint64_t controlPointCount);
 bool containsControlPoint(llvm::Function &F);

--- a/llvm/lib/Transforms/Yk/ControlPoint.cpp
+++ b/llvm/lib/Transforms/Yk/ControlPoint.cpp
@@ -248,7 +248,12 @@ bool llvm::containsControlPoint(llvm::Function &F) {
         Function *CF = CI->getCalledFunction();
         // Is it the patched control point?
         if ((CF != nullptr) && (CF->getName() == CP_PPNAME)) {
-          return true;
+          Value *PPTgt = CI->getArgOperand(PP_TARGET_OPND_IDX);
+          if (Function *Tgt = dyn_cast<Function>(PPTgt)) {
+            if (Tgt->getName() == YK_NEW_CONTROL_POINT) {
+              return true;
+            }
+          }
         }
         // Is it the unpatched control point?
         if ((CF != nullptr) && (CF->getName() == YK_DUMMY_CONTROL_POINT)) {


### PR DESCRIPTION
Before we were assuming that any patch point is the control point.

Whilst we don't anticipate any other patchpoints, it would be prudent to check that the target is actually the control point function.