### PR TITLE
Enable backend optimisations for functions that can't be traced.

### DIFF
--- a/clang/test/Yk/idempotent_inlined_promotions.c
+++ b/clang/test/Yk/idempotent_inlined_promotions.c
@@ -1,0 +1,16 @@
+// Checks the compiler borks if a __yk_promote_* gets inlined into a
+// yk_idempotent function.
+//
+// RUN: not %clang -O2 -mllvm --yk-embed-ir -mllvm --yk-insert-stackmaps %s 2>&1 | FileCheck %s
+
+void *__yk_promote_ptr(void *);
+
+void g(void *p) {
+  __yk_promote_ptr(p);
+}
+
+// CHECK: error: promotion detected in yk_outline annotated function 'main'
+__attribute__((yk_idempotent))
+int main(int argc, char **argv) {
+  g(argv);
+}

--- a/clang/test/Yk/outline_inlined_promotions.c
+++ b/clang/test/Yk/outline_inlined_promotions.c
@@ -1,0 +1,16 @@
+// Checks the compiler borks if a __yk_promote_* gets inlined into a
+// yk_outline function.
+//
+// RUN: not %clang -O2 -mllvm --yk-embed-ir -mllvm --yk-insert-stackmaps %s 2>&1 | FileCheck %s
+
+void *__yk_promote_ptr(void *);
+
+void g(void *p) {
+  __yk_promote_ptr(p);
+}
+
+// CHECK: error: promotion detected in yk_outline annotated function 'main'
+__attribute__((yk_outline))
+int main(int argc, char **argv) {
+  g(argv);
+}

--- a/llvm/lib/LTO/LTOBackend.cpp
+++ b/llvm/lib/LTO/LTOBackend.cpp
@@ -520,12 +520,14 @@ Error lto::backend(const Config &C, AddStreamFn AddStream,
       return Error::success();
   }
 
-  // Yk can't tolerate backend optimisations, so we mark every function with
-  // `optnone` from here onwards. Note that `noinline` is a required
-  // prerequisite of `optnone`.
+  // Yk can't tolerate backend optimisations, so we mark every function that
+  // *could* be traced with `optnone` from here onwards. Note that `noinline`
+  // is a required prerequisite of `optnone`.
   if (YkOptNoneAfterIRPasses) {
     for (Function &F: Mod) {
-      if (!F.isDeclaration()) {
+      if (!F.isDeclaration() &&
+          (!F.hasFnAttribute("yk_outline") || containsControlPoint(F)))
+      {
         F.addFnAttr(Attribute::OptimizeNone);
         F.addFnAttr(Attribute::NoInline);
       }

--- a/llvm/lib/Transforms/Yk/Idempotent.cpp
+++ b/llvm/lib/Transforms/Yk/Idempotent.cpp
@@ -15,6 +15,8 @@
 #include "llvm/IR/Verifier.h"
 #include "llvm/InitializePasses.h"
 #include "llvm/Pass.h"
+#include "llvm/Transforms/Yk/ControlPoint.h"
+#include "llvm/YkIR/YkIRWriter.h"
 
 #define DEBUG_TYPE "yk-stackmaps"
 
@@ -73,6 +75,9 @@ public:
     // the recorder at all returns within the function.
     IRBuilder<> Builder(Context);
     for (Function &F : M) {
+      if (F.hasFnAttribute(YK_OUTLINE_FNATTR) && !containsControlPoint(F)) {
+        continue;
+      }
       for (BasicBlock &BB : F) {
         for (Instruction &I : BB) {
           if (CallBase *CI = dyn_cast<CallBase>(&I)) {

--- a/llvm/lib/Transforms/Yk/StackMaps.cpp
+++ b/llvm/lib/Transforms/Yk/StackMaps.cpp
@@ -19,6 +19,7 @@
 #include "llvm/Transforms/Yk/ControlPoint.h"
 #include "llvm/Transforms/Yk/LivenessAnalysis.h"
 #include "llvm/Transforms/Yk/ModuleClone.h"
+#include "llvm/YkIR/YkIRWriter.h"
 #include <map>
 
 #define DEBUG_TYPE "yk-stackmaps"

--- a/llvm/lib/YkIR/CMakeLists.txt
+++ b/llvm/lib/YkIR/CMakeLists.txt
@@ -3,6 +3,7 @@ add_llvm_component_library(LLVMYkIR
 
   LINK_COMPONENTS
   Core
+  YkPasses
   MC
   Support
   )

--- a/llvm/test/YkIR/yk_idempotent_not_ykoutline.ll
+++ b/llvm/test/YkIR/yk_idempotent_not_ykoutline.ll
@@ -1,0 +1,12 @@
+; Checks the compiler borks if there's a __yk_promote_* in a yk_outline
+; function.
+;
+; RUN: not llc --yk-embed-ir < %s 2>&1 | FileCheck %s
+
+declare ptr @__yk_promote_ptr(ptr)
+
+; CHECK: error: idempotent function f must also be annotated yk_outline
+define void @f(ptr %p) "yk_idempotent" {
+    call ptr @__yk_promote_ptr(ptr %p) ; invalid!
+	ret void
+}


### PR DESCRIPTION
If a function is marked `yk_outline` (and doesn't contain a control point), then we can never trace it, so *in theory* the optimisations that would otherwise break the mapper could actually be used.

There's one small catch though: the trace builder still has to be able to "outline over" `yk_outline` functions, and if the function has IR, the trace builder will try to map the blocks within and make a total mess of it, since the optimisations skewed the mappings.

This change therefore also prevents ykllvm from emitting AOT IR for those functions, effectively making them appear to the trace builder as foreign code, which is then outlined differently, but crucially *without* the need for the mappings to be consistent.

One knock-on requirement is that no `yk_outline` function is permitted to promote values any more, since without IR, we'd never know to consume the promoted bytes.

(A lot of code here was borrowed from a simlar (but distinct) PR: https://github.com/ykjit/ykllvm/pull/239)

When benchmarking CD and Richards, gives speedups in the realms of 10-20% ish.

Note also how CD spends more time in sys after this change, but runs faster overall. Interesting.

```

1: /home/vext01/research/yklua/src/lua-before harness.lua cd 3 250
            Mean        Std.Dev.    Min         Median      Max
real        39.238      0.835       38.105      39.893      39.964
user        96.451      3.320       92.716      96.077      102.050
sys         162.216     11.851      139.544     166.891     171.612

1: /home/vext01/research/yklua/src/lua-after harness.lua cd 3 250
            Mean        Std.Dev.    Min         Median      Max
real        34.846      0.694       33.892      34.710      36.050
user        89.768      1.549       87.430      89.734      91.851
sys         173.440     14.941      152.802     173.968     195.308

1: /home/vext01/research/yklua/src/lua-before harness.lua richards 3 100
            Mean        Std.Dev.    Min         Median      Max
real        21.959      0.223       21.589      21.962      22.275
user        25.826      0.563       24.879      25.914      26.643
sys         3.761       0.203       3.406       3.787       4.004

1: /home/vext01/research/yklua/src/lua-after harness.lua richards 3 100
            Mean        Std.Dev.    Min         Median      Max
real        18.173      0.277       17.672      18.250      18.469
user        21.613      0.723       20.565      21.441      22.533
sys         3.387       1.087       2.385       3.103       5.377
```