### PR TITLE
Add new pass manager support for shadow stack pass

### DIFF
--- a/llvm/include/llvm/Transforms/Yk/ShadowStack.h
+++ b/llvm/include/llvm/Transforms/Yk/ShadowStack.h
@@ -1,10 +1,35 @@
 #ifndef LLVM_TRANSFORMS_YK_SHADOWSTACK_H
 #define LLVM_TRANSFORMS_YK_SHADOWSTACK_H
 
+#include "llvm/IR/PassManager.h"
 #include "llvm/Pass.h"
 
 namespace llvm {
+
+// Legacy Pass Manager wrapper
+class YkShadowStack : public ModulePass {
+public:
+  static char ID;
+  YkShadowStack(uint64_t controlPointCount);
+  bool runOnModule(Module &M) override;
+
+private:
+  uint64_t controlPointCount;
+};
 ModulePass *createYkShadowStackPass(uint64_t controlPointCount);
+
+// New Pass Manager wrapper
+class YkShadowStackNew : public PassInfoMixin<YkShadowStackNew> {
+public:
+  YkShadowStackNew(uint64_t controlPointCount);
+  YkShadowStackNew();
+  PreservedAnalyses run(Module &M, ModuleAnalysisManager &);
+  static StringRef name() { return "YkShadowStack"; }
+
+private:
+  uint64_t controlPointCount;
+};
+
 } // namespace llvm
 
-#endif
+#endif // LLVM_TRANSFORMS_YK_SHADOWSTACK_H

--- a/llvm/lib/CodeGen/TargetPassConfig.cpp
+++ b/llvm/lib/CodeGen/TargetPassConfig.cpp
@@ -277,7 +277,7 @@ static cl::opt<bool> YkLinkage("yk-linkage", cl::init(false),
                                       cl::desc("Change functions with internal linkage to have external linkage"));
 
 static cl::opt<bool>
-    YkShadowStack("yk-shadow-stack", cl::init(false), cl::NotHidden,
+    YkShadowStackOpt("yk-shadow-stack", cl::init(false), cl::NotHidden,
                   cl::desc("Use a shadow stack for stack values."));
 
 static cl::opt<bool>
@@ -1162,7 +1162,7 @@ bool TargetPassConfig::addISelPasses() {
     addPass(createYkNoCallsInEntryBlocksPass());
   }
 
-  if (YkShadowStack) {
+  if (YkShadowStackOpt) {
     addPass(createYkShadowStackPass(numberOfControlPoints));
   }
   // We insert the yk control point pass as late as possible. It has to run

--- a/llvm/lib/Passes/CMakeLists.txt
+++ b/llvm/lib/Passes/CMakeLists.txt
@@ -30,4 +30,5 @@ add_llvm_component_library(LLVMPasses
   TransformUtils
   Vectorize
   Instrumentation
+  YkPasses
   )

--- a/llvm/lib/Passes/PassBuilder.cpp
+++ b/llvm/lib/Passes/PassBuilder.cpp
@@ -264,6 +264,7 @@
 #include "llvm/Transforms/Vectorize/LoopVectorize.h"
 #include "llvm/Transforms/Vectorize/SLPVectorizer.h"
 #include "llvm/Transforms/Vectorize/VectorCombine.h"
+#include "llvm/Transforms/Yk/ShadowStack.h"
 #include <optional>
 
 using namespace llvm;

--- a/llvm/lib/Passes/PassRegistry.def
+++ b/llvm/lib/Passes/PassRegistry.def
@@ -132,6 +132,8 @@ MODULE_PASS("sanmd-module", SanitizerBinaryMetadataPass())
 MODULE_PASS("memprof-module", ModuleMemProfilerPass())
 MODULE_PASS("poison-checking", PoisonCheckingPass())
 MODULE_PASS("pseudo-probe-update", PseudoProbeUpdatePass())
+MODULE_PASS("yk-shadow-stack", YkShadowStackNew())
+
 #undef MODULE_PASS
 
 #ifndef MODULE_PASS_WITH_PARAMS


### PR DESCRIPTION
Shadow stack passes can now be invoked with the `opt -passes` argument as well as the old legacy pass manager. This is needed for future shadow stack PRs which will use non-legacy passes during setup in tests.