### PR TITLE
Make shadow stack debuggable

### DIFF
--- a/llvm/lib/Transforms/Yk/ShadowStack.cpp
+++ b/llvm/lib/Transforms/Yk/ShadowStack.cpp
@@ -83,7 +83,9 @@
 
 #include "llvm/Transforms/Yk/ShadowStack.h"
 #include "llvm/IR/BasicBlock.h"
+#include "llvm/IR/DIBuilder.h"
 #include "llvm/IR/DataLayout.h"
+#include "llvm/IR/DebugInfoMetadata.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Instructions.h"
@@ -120,6 +122,7 @@ class YkShadowStackImpl {
   Type *Int8PtrTy = nullptr;
   Type *Int32Ty = nullptr;
   Type *PointerSizedIntTy = nullptr;
+  std::unique_ptr<DIBuilder> DIB;
   using AllocaVector = std::vector<std::pair<AllocaInst *, size_t>>;
 
 private:
@@ -145,6 +148,40 @@ public:
       }
     }
     return false;
+  }
+
+  // Insert a shadowstack_ptr debug variable when compiled with '-g' so that in
+  // gdb we can know the offset into the shadow stack for each frame. This uses
+  // llvm's debug intrinsic so does not affect optimized code.
+  void insertShadowDbgInfo(Function &F, DataLayout &DL, GlobalValue *SSGlobal,
+                           size_t SFrameSize) {
+    DISubprogram *SP = F.getSubprogram();
+    if (!SP) {
+      return;
+    }
+    DIBasicType *DISSTy = DIB->createBasicType("shadowstack", SFrameSize * 8,
+                                               dwarf::DW_ATE_address);
+    DIDerivedType *DISSPtrTy = DIB->createPointerType(
+        DISSTy, DL.getPointerSize(), DL.getPointerABIAlignment(0).value(),
+        std::nullopt, "shadowstack_ptr");
+
+    // Create a debug local var to our opaque shadow stack block
+    DILocalVariable *DebugVar = DIB->createAutoVariable(
+        SP, "shadowstack", SP->getFile(), SP->getLine(), DISSPtrTy,
+        false, // AlwaysPreserve
+        DINode::DIFlags::FlagArtificial);
+
+    // And insert it at the beginning of the function
+    DILocation *DIL = DILocation::get(F.getContext(), SP->getLine(), 0, SP);
+    Instruction *InsertBefore = &*F.getEntryBlock().getFirstInsertionPt();
+    Instruction *First = F.getEntryBlock().getFirstNonPHI();
+    IRBuilder<> Builder(First);
+
+    // Load the shadow stack pointer out of the global variable and assign it
+    // to our debug local.
+    Value *SSPtr = Builder.CreateLoad(Int8PtrTy, SSGlobal);
+    DIB->insertDbgValueIntrinsic(SSPtr, DebugVar, DIB->createExpression(), DIL,
+                                 InsertBefore);
   }
 
   // Insert main's prologue.
@@ -378,6 +415,13 @@ public:
 
   bool run(Module &M) {
     LLVMContext &Context = M.getContext();
+    llvm::NamedMDNode *CU_Nodes = M.getNamedMetadata("llvm.dbg.cu");
+    if (CU_Nodes && CU_Nodes->getNumOperands() > 0) {
+      llvm::DICompileUnit *CU =
+          llvm::cast<llvm::DICompileUnit>(CU_Nodes->getOperand(0));
+
+      DIB = std::make_unique<DIBuilder>(M, false, CU);
+    }
 
     // Cache commonly used types.
     Int8Ty = Type::getInt8Ty(Context);
@@ -419,10 +463,15 @@ public:
       size_t SFrameSize = analyseFunction(F, DL, Allocas, Rets);
       if (SFrameSize > 0) {
         Value *InitSSPtr = insertShadowPrologue(F, SSGlobal, SFrameSize);
+        insertShadowDbgInfo(F, DL, SSGlobal, SFrameSize);
         rewriteAllocas(DL, Allocas, InitSSPtr);
         insertShadowEpilogues(Rets, SSGlobal, InitSSPtr);
       }
     }
+
+    // Finalize the DIBuilder after all debug info is created
+    if (DIB)
+      DIB->finalize();
 
 #ifndef NDEBUG
     // Our pass runs after LLVM normally does its verify pass. In debug builds

--- a/llvm/test/Transforms/Yk/ShadowStackDebug.ll
+++ b/llvm/test/Transforms/Yk/ShadowStackDebug.ll
@@ -1,0 +1,71 @@
+; Checks that the shadow stack debug variable is inserted
+;
+; RUN: opt -passes='default<O0>,debugify,yk-shadow-stack' -S %s  | FileCheck %s
+
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+declare ptr @yk_mt_new();
+declare ptr @yk_location_new();
+%struct.YkLocation = type { i64 }
+
+; The pass should insert a global variable to hold the shadow stack pointer.
+; CHECK: @shadowstack_0 = thread_local global ptr null
+; CHECK: ![[SHADOWSTACK:[0-9]+]] = !DILocalVariable(name: "shadowstack",{{.*}}flags: DIFlagArtificial)
+
+define dso_local i32 @f(i32 noundef %x, i32 noundef %y, i32 noundef %z) noinline optnone {
+entry:
+  %retval = alloca i32, align 4
+  %x.addr = alloca i32, align 4
+  %y.addr = alloca i32, align 4
+  %z.addr = alloca i32, align 4
+  store i32 %x, ptr %x.addr, align 4
+  store i32 %y, ptr %y.addr, align 4
+  store i32 %z, ptr %z.addr, align 4
+  %0 = load i32, ptr %x.addr, align 4
+  %cmp = icmp sgt i32 %0, 3
+  br i1 %cmp, label %if.then, label %if.else
+
+if.then:
+  %1 = load i32, ptr %y.addr, align 4
+  %2 = load i32, ptr %z.addr, align 4
+  %add = add nsw i32 %1, %2
+  store i32 %add, ptr %retval, align 4
+  br label %return
+
+if.else:
+  %3 = load i32, ptr %x.addr, align 4
+  %4 = load i32, ptr %y.addr, align 4
+  %add1 = add nsw i32 %3, %4
+  store i32 %add1, ptr %retval, align 4
+  br label %return
+
+return:
+  %5 = load i32, ptr %retval, align 4
+  ret i32 %5
+}
+
+define dso_local void @g() optnone noinline {
+entry:
+  ret void
+}
+
+define dso_local i32 @main(i32 noundef %argc, ptr noundef %argv) noinline optnone {
+entry:
+  %retval = alloca i32, align 4
+  %argc.addr = alloca i32, align 4
+  %argv.addr = alloca ptr, align 8
+  %vs = alloca [3 x i32], align 4
+  %i = alloca i32, align 4
+  %mt_stack = alloca ptr, align 8 ; this should not end up on the shadow stack
+  %loc_stack = alloca %struct.YkLocation, align 8 ; nor this.
+  store i32 0, ptr %retval, align 4
+  store i32 %argc, ptr %argc.addr, align 4
+  store ptr %argv, ptr %argv.addr, align 8
+  %mt = call ptr @yk_mt_new()
+  store ptr %mt, ptr %mt_stack
+  %loc = call ptr @yk_location_new()
+  store ptr %loc, ptr %loc_stack
+  %lrv = load i32, ptr %retval, align 4
+  ret i32 %lrv
+}


### PR DESCRIPTION
Debugging the shadow stack inside gdb is hard because it moves all the locals around breaking gdb assumptions. This patch makes it a little easier to debug by creating a 'debug local' for each stack frame which points to the frame's corresponding shadow stack offset. The 'shadowstack' pointer is then visible in gdb with 'info locals'.

This relies solely on LLVM's debug intrinsic library, so does not affect code generation when the '-g' flag is not set.