### PR TITLE
Encode synthetic conditional branch info in the blockmap and turn off stackmaps in stuff that can't be traced.

### DIFF
--- a/llvm/include/llvm/CodeGen/TargetInstrInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetInstrInfo.h
@@ -651,6 +651,22 @@ public:
     return true;
   }
 
+  /// Similar to `analyzeBranch()` but for blocks with conditional terminators,
+  /// also computes the number of low-level conditional branch instructions at
+  /// the end of the block. This is required because some targets use
+  /// synthetic conditional terminators that are really several conditional
+  /// branches in succession.
+  ///
+  /// yk JIT uses this during compiler-assisted PT decoding in order to know
+  /// how to correctly follow a conditional terminator.
+  virtual bool analyzeBranchExtended(MachineBasicBlock &MBB, MachineBasicBlock *&TBB,
+                             MachineBasicBlock *&FBB,
+                             SmallVectorImpl<MachineOperand> &Cond,
+                             uint8_t &NumCondBrs,
+                             bool AllowModify = false) const {
+    report_fatal_error("not implemented on this platform");
+  }
+
   /// Represents a predicate at the MachineFunction level.  The control flow a
   /// MachineBranchPredicate represents is:
   ///

--- a/llvm/lib/Target/X86/X86InstrInfo.cpp
+++ b/llvm/lib/Target/X86/X86InstrInfo.cpp
@@ -3232,6 +3232,49 @@ bool X86InstrInfo::AnalyzeBranchImpl(
   return false;
 }
 
+bool X86InstrInfo::analyzeBranchExtended(MachineBasicBlock &MBB, MachineBasicBlock *&TBB,
+                             MachineBasicBlock *&FBB,
+                             SmallVectorImpl<MachineOperand> &Cond,
+                             uint8_t &NumCondBrs,
+                             bool AllowModify) const {
+  bool Ret = analyzeBranch(MBB, TBB, FBB, Cond, AllowModify);
+  if (Cond.size() == 0) {
+    NumCondBrs = 0;
+  } else if (Cond.size() == 1) {
+    switch ((X86::CondCode)Cond[0].getImm()) {
+      case X86::COND_O:
+      case X86::COND_NO:
+      case X86::COND_B:
+      case X86::COND_AE:
+      case X86::COND_E:
+      case X86::COND_NE:
+      case X86::COND_BE:
+      case X86::COND_A:
+      case X86::COND_S:
+      case X86::COND_NS:
+      case X86::COND_P:
+      case X86::COND_NP:
+      case X86::COND_L:
+      case X86::COND_GE:
+      case X86::COND_LE:
+      case X86::COND_G:
+        NumCondBrs = 1;
+        break;
+      case X86::COND_NE_OR_P:
+      case X86::COND_E_AND_NP:
+        NumCondBrs = 2;
+        break;
+      default:
+        report_fatal_error("Unhandled condition");
+        break;
+    }
+  } else {
+    report_fatal_error("Unimplemented");
+  }
+  return Ret;
+}
+
+
 bool X86InstrInfo::analyzeBranch(MachineBasicBlock &MBB,
                                  MachineBasicBlock *&TBB,
                                  MachineBasicBlock *&FBB,

--- a/llvm/lib/Target/X86/X86InstrInfo.h
+++ b/llvm/lib/Target/X86/X86InstrInfo.h
@@ -329,6 +329,12 @@ public:
                      SmallVectorImpl<MachineOperand> &Cond,
                      bool AllowModify) const override;
 
+  bool analyzeBranchExtended(MachineBasicBlock &MBB, MachineBasicBlock *&TBB,
+                             MachineBasicBlock *&FBB,
+                             SmallVectorImpl<MachineOperand> &Cond,
+                             uint8_t &NumCondBrs,
+                             bool AllowModify = false) const override;
+
   int getJumpTableIndex(const MachineInstr &MI) const override;
 
   std::optional<ExtAddrMode>

--- a/llvm/lib/Transforms/Yk/StackMaps.cpp
+++ b/llvm/lib/Transforms/Yk/StackMaps.cpp
@@ -59,6 +59,9 @@ public:
         continue;
       if (F.getName().startswith(YK_UNOPT_PREFIX)) // skip cloned functions
         continue;
+      if (F.hasFnAttribute("yk_outline") && !(containsControlPoint(F))) {
+        continue;
+      }
 
       LivenessAnalysis LA(&F);
       for (BasicBlock &BB : F) {


### PR DESCRIPTION
First commit is a correctness fix.

Second (requires the first) is an optimisation.