### PR TITLE
Record start pointer and size for the shadow-stack buffer

### DIFF
--- a/llvm/lib/Transforms/Yk/ShadowStack.cpp
+++ b/llvm/lib/Transforms/Yk/ShadowStack.cpp
@@ -103,6 +103,8 @@
 #define DEBUG_TYPE "yk-shadow-stack-pass"
 #define YK_MT_NEW "yk_mt_new"
 #define G_SHADOW_STACK "shadowstack_0"
+#define G_SHADOW_HEAD "shadowstack_head"
+#define G_SHADOW_SIZE "shadowstack_size"
 #define MAIN "main"
 // The size of the shadow stack. Defaults to 1MB.
 // YKFIXME: Make this adjustable by a compiler flag.
@@ -123,6 +125,10 @@ class YkShadowStackImpl {
   Type *Int32Ty = nullptr;
   Type *PointerSizedIntTy = nullptr;
   std::unique_ptr<DIBuilder> DIB;
+
+  GlobalVariable *ShadowCurrent;
+  GlobalVariable *ShadowHead;
+
   using AllocaVector = std::vector<std::pair<AllocaInst *, size_t>>;
 
 private:
@@ -153,8 +159,7 @@ public:
   // Insert a shadowstack_ptr debug variable when compiled with '-g' so that in
   // gdb we can know the offset into the shadow stack for each frame. This uses
   // llvm's debug intrinsic so does not affect optimized code.
-  void insertShadowDbgInfo(Function &F, DataLayout &DL, GlobalValue *SSGlobal,
-                           size_t SFrameSize) {
+  void insertShadowDbgInfo(Function &F, DataLayout &DL, size_t SFrameSize) {
     DISubprogram *SP = F.getSubprogram();
     if (!SP) {
       return;
@@ -179,7 +184,7 @@ public:
 
     // Load the shadow stack pointer out of the global variable and assign it
     // to our debug local.
-    Value *SSPtr = Builder.CreateLoad(Int8PtrTy, SSGlobal);
+    Value *SSPtr = Builder.CreateLoad(Int8PtrTy, ShadowCurrent);
     DIB->insertDbgValueIntrinsic(SSPtr, DebugVar, DIB->createExpression(), DIL,
                                  InsertBefore);
   }
@@ -191,8 +196,7 @@ public:
   //
   // Returns a pointer to the result of the call to malloc that was used to
   // heap allocate memory for a shadow stack.
-  CallInst *insertMainPrologue(Function *Main, GlobalVariable *SSGlobal,
-                               size_t SFrameSize) {
+  CallInst *insertMainPrologue(Function *Main, size_t SFrameSize) {
     Module *M = Main->getParent();
     Instruction *First = Main->getEntryBlock().getFirstNonPHI();
     IRBuilder<> Builder(First);
@@ -203,17 +207,19 @@ public:
     CallInst *Malloc = Builder.CreateCall(
         MF, {ConstantInt::get(PointerSizedIntTy, SHADOW_STACK_SIZE)}, "");
 
+    Builder.CreateStore(Malloc, ShadowHead);
+
     // If main() needs shadow space, reserve some.
     if (SFrameSize > 0) {
       GetElementPtrInst *GEP = GetElementPtrInst::Create(
           Int8Ty, Malloc, {ConstantInt::get(Int32Ty, SFrameSize)}, "",
           Malloc->getNextNode());
       // Update the global variable keeping track of the top of shadow stack.
-      Builder.CreateStore(GEP, SSGlobal);
+      Builder.CreateStore(GEP, ShadowCurrent);
     } else {
       // If main doesn't require any shadow stack space then we simply
       // initialise the global with the result of the call to malloc().
-      Builder.CreateStore(Malloc, SSGlobal);
+      Builder.CreateStore(Malloc, ShadowCurrent);
     }
 
     return Malloc;
@@ -293,18 +299,17 @@ public:
   //
   // Returns the shadow stack pointer before more space is allocated. Local
   // variables for the shadow frame will be pointers relative to this.
-  Value *insertShadowPrologue(Function &F, GlobalValue *SSGlobal,
-                              size_t AllocSize) {
+  Value *insertShadowPrologue(Function &F, size_t AllocSize) {
     Instruction *First = F.getEntryBlock().getFirstNonPHI();
     IRBuilder<> Builder(First);
 
     // Load the shadow stack pointer out of the global variable.
-    Value *InitSSPtr = Builder.CreateLoad(Int8PtrTy, SSGlobal);
+    Value *InitSSPtr = Builder.CreateLoad(Int8PtrTy, ShadowCurrent);
     // Add space for F's shadow frame.
     GetElementPtrInst *GEP = GetElementPtrInst::Create(
         Int8Ty, InitSSPtr, {ConstantInt::get(Int32Ty, AllocSize)}, "", First);
     // Update the global variable keeping track of the top of shadow stack.
-    Builder.CreateStore(GEP, SSGlobal);
+    Builder.CreateStore(GEP, ShadowCurrent);
 
     return InitSSPtr;
   }
@@ -330,10 +335,10 @@ public:
   /// stack pointer to it's initial value (as it was before the prologue
   /// allocate shadow sack space).
   void insertShadowEpilogues(std::vector<ReturnInst *> &Rets,
-                             GlobalVariable *SSGlobal, Value *InitSSPtr) {
+                             Value *InitSSPtr) {
     for (ReturnInst *RI : Rets) {
       IRBuilder<> Builder(RI);
-      Builder.CreateStore(InitSSPtr, SSGlobal);
+      Builder.CreateStore(InitSSPtr, ShadowCurrent);
     }
   }
 
@@ -349,8 +354,7 @@ public:
   //
   // YKFIXME: Investigate languages that don't have/use main as the first
   // entry point.
-  void updateMainFunctions(DataLayout &DL, Module &M, GlobalVariable *SSGlobal,
-                           LLVMContext &Context) {
+  void updateMainFunctions(DataLayout &DL, Module &M, LLVMContext &Context) {
     Function *Main = M.getFunction(MAIN);
     if (Main == nullptr || Main->isDeclaration()) {
       Context.emitError("Unable to add shadow stack: could not find definition "
@@ -362,7 +366,7 @@ public:
     AllocaVector MainAllocas;
     std::vector<ReturnInst *> MainRets;
     size_t SFrameSize = analyseFunction(*Main, DL, MainAllocas, MainRets);
-    CallInst *Malloc = insertMainPrologue(Main, SSGlobal, SFrameSize);
+    CallInst *Malloc = insertMainPrologue(Main, SFrameSize);
     auto MainGEPs = rewriteAllocas(DL, MainAllocas, Malloc);
 
     // If we have two control points, we need to update the cloned main
@@ -380,13 +384,13 @@ public:
       std::vector<ReturnInst *> UnoptMainRets;
       analyseFunction(*UnoptMain, DL, UnoptMainAllocas, UnoptMainRets);
 
-      // Insert a load of SSGlobal at the beginning of UnoptMain.
+      // Insert a load of ShadowCurrent at the beginning of UnoptMain.
       BasicBlock &EntryBB = UnoptMain->getEntryBlock();
       Instruction *FirstNonPHI = EntryBB.getFirstNonPHI();
       IRBuilder<> Builder(FirstNonPHI);
 
       // Load the current shadow stack pointer from the global variable.
-      LoadInst *LoadedSSPtr = Builder.CreateLoad(Int8PtrTy, SSGlobal);
+      LoadInst *LoadedSSPtr = Builder.CreateLoad(Int8PtrTy, ShadowCurrent);
       // Assert that the allocas count match between opt/unopt main
       assert(MainAllocas.size() == UnoptMainAllocas.size() &&
              "Expected same number of allocas between opt/unopt main");
@@ -430,18 +434,26 @@ public:
     DataLayout DL(&M);
     PointerSizedIntTy = DL.getIntPtrType(Context);
 
-    // Create a global variable which will store the pointer to the heap memory
-    // used by the shadow stack.
-    //
-    // YKFIXME: This isn't thread safe. For now interpreters are assumed to be
-    // single threaded: https://github.com/ykjit/yk/issues/794
-    GlobalVariable *SSGlobal =
-        cast<GlobalVariable>(M.getOrInsertGlobal(G_SHADOW_STACK, Int8PtrTy));
-    SSGlobal->setInitializer(
-        ConstantPointerNull::get(cast<PointerType>(Int8PtrTy)));
-    SSGlobal->setThreadLocal(true);
+    GlobalVariable *ShadowSize =
+        cast<GlobalVariable>(M.getOrInsertGlobal(G_SHADOW_SIZE, Int32Ty));
+    ShadowSize->setInitializer(
+        ConstantInt::get(Int32Ty, SHADOW_STACK_SIZE, false));
+    ShadowSize->setSection(".rodata");
+    ShadowSize->setLinkage(llvm::GlobalValue::ExternalLinkage);
 
-    updateMainFunctions(DL, M, SSGlobal, Context);
+    ShadowCurrent =
+        cast<GlobalVariable>(M.getOrInsertGlobal(G_SHADOW_STACK, Int8PtrTy));
+    ShadowCurrent->setInitializer(
+        ConstantPointerNull::get(cast<PointerType>(Int8PtrTy)));
+    ShadowHead =
+        cast<GlobalVariable>(M.getOrInsertGlobal(G_SHADOW_HEAD, Int8PtrTy));
+    ShadowHead->setInitializer(
+        ConstantPointerNull::get(cast<PointerType>(Int8PtrTy)));
+
+    ShadowCurrent->setThreadLocal(true);
+    ShadowHead->setThreadLocal(true);
+
+    updateMainFunctions(DL, M, Context);
 
     // Instrument each remaining function with shadow stack code.
     for (Function &F : M) {
@@ -462,10 +474,10 @@ public:
       std::vector<ReturnInst *> Rets;
       size_t SFrameSize = analyseFunction(F, DL, Allocas, Rets);
       if (SFrameSize > 0) {
-        Value *InitSSPtr = insertShadowPrologue(F, SSGlobal, SFrameSize);
-        insertShadowDbgInfo(F, DL, SSGlobal, SFrameSize);
+        Value *InitSSPtr = insertShadowPrologue(F, SFrameSize);
+        insertShadowDbgInfo(F, DL, SFrameSize);
         rewriteAllocas(DL, Allocas, InitSSPtr);
-        insertShadowEpilogues(Rets, SSGlobal, InitSSPtr);
+        insertShadowEpilogues(Rets, InitSSPtr);
       }
     }
 

--- a/llvm/test/Transforms/Yk/ShadowStack.ll
+++ b/llvm/test/Transforms/Yk/ShadowStack.ll
@@ -11,7 +11,9 @@ declare ptr @yk_location_new();
 %struct.YkLocation = type { i64 }
 
 ; The pass should insert a global variable to hold the shadow stack pointer.
+; CHECK: @shadowstack_size = global i32 1000000, section ".rodata"
 ; CHECK: @shadowstack_0 = thread_local global ptr null
+; CHECK: @shadowstack_head = thread_local global ptr null
 
 ; Check a non-main function that requires some shadow space.
 ;
@@ -82,6 +84,7 @@ entry:
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    %0 = call ptr @malloc(i64 1000000)
 ; CHECK-NEXT:    %1 = getelementptr i8, ptr %0, i32 32
+; CHECK-NEXT:    store ptr %0, ptr @shadowstack_head, align 8
 ; CHECK-NEXT:    store ptr %1, ptr @shadowstack_0, align 8
 ; CHECK-NEXT:    %2 = getelementptr i8, ptr %0, i32 0
 ; CHECK-NEXT:    %3 = getelementptr i8, ptr %0, i32 4

--- a/llvm/test/Transforms/Yk/ShadowStackZeroMain.ll
+++ b/llvm/test/Transforms/Yk/ShadowStackZeroMain.ll
@@ -9,7 +9,9 @@ declare ptr @yk_location_new();
 %struct.YkLocation = type { i64 }
 
 ; The pass should insert a global variable to hold the shadow stack pointer.
+; CHECK: @shadowstack_size = global i32 1000000, section ".rodata"
 ; CHECK: @shadowstack_0 = thread_local global ptr null
+; CHECK: @shadowstack_head = thread_local global ptr null
 
 ; Check that a main fucntion requiring no shadow space doesn't needlessly
 ; fiddle with the shadow stack pointer.
@@ -19,6 +21,7 @@ declare ptr @yk_location_new();
 ; CHECK:       define dso_local i32 @main(i32 noundef %argc, ptr noundef %argv) #0 {
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    %0 = call ptr @malloc(i64 1000000)
+; CHECK-NEXT:    store ptr %0, ptr @shadowstack_head, align 8
 ; CHECK-NEXT:    store ptr %0, ptr @shadowstack_0, align 8
 ; CHECK-NEXT:    ret i32 0
 ; CHECK-NEXT:  }


### PR DESCRIPTION
In order to support VMs which use tracing garbage collection, we need to provide a way for them to scan the shadow stack during marking. The simplest way is export the start pointers and size for the shadow-stack heap allocation.