### PR TITLE
Various fixes related to the FixStackmapsSpillReloads pass.

### DIFF
--- a/llvm/lib/CodeGen/Yk/FixStackmapsSpillReloads.cpp
+++ b/llvm/lib/CodeGen/Yk/FixStackmapsSpillReloads.cpp
@@ -46,6 +46,7 @@
 #include "llvm/CodeGen/Passes.h"
 #include "llvm/CodeGen/StackMaps.h"
 #include "llvm/CodeGen/TargetInstrInfo.h"
+#include "llvm/CodeGen/LivePhysRegs.h"
 #include "llvm/IR/DebugLoc.h"
 #include "llvm/InitializePasses.h"
 #include "llvm/Support/Debug.h"
@@ -98,6 +99,7 @@ bool FixStackmapsSpillReloads::runOnMachineFunction(MachineFunction &MF) {
   for (MachineBasicBlock &MBB : MF) {
     bool Collect = false;
     std::set<MachineInstr *> Erased;
+    std::set<MachineInstr *> NewInstrs;
     MachineInstr *LastCall = nullptr;
     std::map<Register, MachineInstr *> Spills;
     for (MachineInstr &MI : MBB) {
@@ -167,15 +169,25 @@ bool FixStackmapsSpillReloads::runOnMachineFunction(MachineFunction &MF) {
                 // with multiple operands describing a stack location.
                 std::optional<unsigned> Size = SMI->getRestoreSize(TII);
                 if(!Size.has_value()) {
-                  // This reload isn't a spill (e.g. this could be loading an
-                  // argument passed via the stack), so we don't need to
-                  // replace it. Since registers in lower frames aren't reset
-                  // during deopt, this is only of consequence to the top stack
-                  // frame. And even there this will simply temporarily put a
-                  // value into the register MOI, only to then immediately
-                  // reload the same value into MOI once the reload instruction
-                  // `SMI` is executed after deopt returns to normal execution.
-                  MIB.add(*MOI);
+                  // This reload isn't a spill, e.g. this could be loading an
+                  // argument passed via the stack and look like this:
+                  //
+                  //   mov rax, rbp + 10
+                  //   STACKMAP rax
+                  //
+                  // We know that, after moving the stackmap, following the
+                  // stackmap instruction we'll immediately write to the
+                  // tracked register, so there is no need to track it at all.
+                  // However, we can't just remove the operand as that would
+                  // change the order of the tracked values and means we can't
+                  // match them to LLVM IR operands anymore. Leaving the
+                  // operand in also doesn't work as the verifier then
+                  // sometimes complains about the use of undefined registers.
+                  // Instead, we can just insert a constant `0xdead`, which has
+                  // no consequences for deopt (it will just be ignored) but is
+                  // something we can easily spot if things go wrong.
+                  MIB.addImm(StackMaps::ConstantOp);
+                  MIB.addImm(0xdead);
                 } else {
                   MIB.addImm(StackMaps::IndirectMemRefOp);
                   MIB.addImm(Size.value()); // Size
@@ -231,6 +243,7 @@ bool FixStackmapsSpillReloads::runOnMachineFunction(MachineFunction &MF) {
         MI.getParent()->insertAfter(LastCall, NewMI);
         // Remember the old stackmap instruction for deletion later.
         Erased.insert(&MI);
+        NewInstrs.insert(NewMI);
         LastCall = nullptr;
         Changed = true;
       }
@@ -259,7 +272,31 @@ bool FixStackmapsSpillReloads::runOnMachineFunction(MachineFunction &MF) {
     for (MachineInstr *E : Erased) {
       E->eraseFromParent();
     }
-  }
+    if (Erased.size() > 0) {
+      // Did we move any stackmaps around? If so, recompute register liveness
+      // which we may have messed up.
+      recomputeLivenessFlags(MBB);
+    }
 
+
+    // Remove any implicit kills that are no longer valid.
+    for (MachineInstr *MI : NewInstrs) {
+      // Iterate backwards as we are removing operands as we go along.
+      MachineInstr::mop_iterator Imp = MI->implicit_operands().end();
+      MachineInstr::mop_iterator ImpEnd = MI->implicit_operands().begin();
+      for (; Imp != ImpEnd;) {
+        Imp--;
+        if (Imp->isReg() && Imp->isKill()) {
+          if (MBB.computeRegisterLiveness(TRI, Imp->getReg(), MI) == MachineBasicBlock::LivenessQueryResult::LQR_Live) {
+            MI->removeOperand(MI->getOperandNo(Imp));
+          }
+        }
+      }
+    }
+  }
+  if (Changed) {
+    // If we've made any changes, verify them.
+    MF.verify();
+  }
   return Changed;
 }

--- a/llvm/lib/CodeGen/Yk/FixStackmapsSpillReloads.cpp
+++ b/llvm/lib/CodeGen/Yk/FixStackmapsSpillReloads.cpp
@@ -36,6 +36,7 @@
 // call.
 //===----------------------------------------------------------------------===//
 
+#include "llvm/CodeGen/LivePhysRegs.h"
 #include "llvm/CodeGen/MachineBasicBlock.h"
 #include "llvm/CodeGen/MachineFrameInfo.h"
 #include "llvm/CodeGen/MachineFunction.h"
@@ -46,7 +47,6 @@
 #include "llvm/CodeGen/Passes.h"
 #include "llvm/CodeGen/StackMaps.h"
 #include "llvm/CodeGen/TargetInstrInfo.h"
-#include "llvm/CodeGen/LivePhysRegs.h"
 #include "llvm/IR/DebugLoc.h"
 #include "llvm/InitializePasses.h"
 #include "llvm/Support/Debug.h"
@@ -85,10 +85,10 @@ public:
 char FixStackmapsSpillReloads::ID = 0;
 char &llvm::FixStackmapsSpillReloadsID = FixStackmapsSpillReloads::ID;
 
-INITIALIZE_PASS_BEGIN(FixStackmapsSpillReloads, DEBUG_TYPE, "Fixup Stackmap Spills",
-                      false, false)
-INITIALIZE_PASS_END(FixStackmapsSpillReloads, DEBUG_TYPE, "Fixup Stackmap Spills",
-                    false, false)
+INITIALIZE_PASS_BEGIN(FixStackmapsSpillReloads, DEBUG_TYPE,
+                      "Fixup Stackmap Spills", false, false)
+INITIALIZE_PASS_END(FixStackmapsSpillReloads, DEBUG_TYPE,
+                    "Fixup Stackmap Spills", false, false)
 
 const TargetRegisterInfo *TRI;
 
@@ -109,7 +109,8 @@ bool FixStackmapsSpillReloads::runOnMachineFunction(MachineFunction &MF) {
         if (MI.getOpcode() != TargetOpcode::STACKMAP &&
             MI.getOpcode() != TargetOpcode::PATCHPOINT) {
           MachineOperand Op = MI.getOperand(0);
-          if (Op.isGlobal() && Op.getGlobal()->getGlobalIdentifier() == YK_TRACE_FUNCTION) {
+          if (Op.isGlobal() &&
+              Op.getGlobal()->getGlobalIdentifier() == YK_TRACE_FUNCTION) {
             // `YK_TRACE_FUNCTION` calls don't require stackmaps so we don't
             // need to adjust anything here. In fact, doing so will skew any
             // stackmap that follows.
@@ -137,8 +138,8 @@ bool FixStackmapsSpillReloads::runOnMachineFunction(MachineFunction &MF) {
         // Assemble a new stackmap instruction by copying over the operands of
         // the old instruction to the new one, while replacing spilled operands
         // as we go.
-        MachineInstr *NewMI =
-          MF.CreateMachineInstr(TII->get(TargetOpcode::STACKMAP), MI.getDebugLoc(), true);
+        MachineInstr *NewMI = MF.CreateMachineInstr(
+            TII->get(TargetOpcode::STACKMAP), MI.getDebugLoc(), true);
         MachineInstrBuilder MIB(MF, NewMI);
         // Copy ID and shadow
         auto *MOI = MI.operands_begin();
@@ -168,7 +169,7 @@ bool FixStackmapsSpillReloads::runOnMachineFunction(MachineFunction &MF) {
                 // If the reload is a load from the stack, replace the operand
                 // with multiple operands describing a stack location.
                 std::optional<unsigned> Size = SMI->getRestoreSize(TII);
-                if(!Size.has_value()) {
+                if (!Size.has_value()) {
                   // This reload isn't a spill, e.g. this could be loading an
                   // argument passed via the stack and look like this:
                   //
@@ -190,7 +191,7 @@ bool FixStackmapsSpillReloads::runOnMachineFunction(MachineFunction &MF) {
                   MIB.addImm(0xdead);
                 } else {
                   MIB.addImm(StackMaps::IndirectMemRefOp);
-                  MIB.addImm(Size.value()); // Size
+                  MIB.addImm(Size.value());    // Size
                   MIB.add(SMI->getOperand(1)); // Register
                   MIB.add(SMI->getOperand(4)); // Offset
                 }
@@ -206,30 +207,32 @@ bool FixStackmapsSpillReloads::runOnMachineFunction(MachineFunction &MF) {
           // Copy all other operands over as is.
           MIB.add(*MOI);
           switch (MOI->getImm()) {
-            default:
-              llvm_unreachable("Unrecognized operand type.");
-            case StackMaps::DirectMemRefOp: {
-              MOI++;
-              MIB.add(*MOI); // Register
-              MOI++;
-              MIB.add(*MOI); // Offset
-              break;
-            }
-            case StackMaps::IndirectMemRefOp: {
-              MOI++;
-              MIB.add(*MOI); // Size
-              MOI++;
-              MIB.add(*MOI); // Register
-              MOI++;
-              MIB.add(*MOI); // Offset
-              break;
-            }
-            case StackMaps::ConstantOp: {
-              MOI++;
-              MIB.add(*MOI);
-              break;
-            }
-            case StackMaps::NextLive: {break;}
+          default:
+            llvm_unreachable("Unrecognized operand type.");
+          case StackMaps::DirectMemRefOp: {
+            MOI++;
+            MIB.add(*MOI); // Register
+            MOI++;
+            MIB.add(*MOI); // Offset
+            break;
+          }
+          case StackMaps::IndirectMemRefOp: {
+            MOI++;
+            MIB.add(*MOI); // Size
+            MOI++;
+            MIB.add(*MOI); // Register
+            MOI++;
+            MIB.add(*MOI); // Offset
+            break;
+          }
+          case StackMaps::ConstantOp: {
+            MOI++;
+            MIB.add(*MOI);
+            break;
+          }
+          case StackMaps::NextLive: {
+            break;
+          }
           }
           MOI++;
         }
@@ -278,7 +281,6 @@ bool FixStackmapsSpillReloads::runOnMachineFunction(MachineFunction &MF) {
       recomputeLivenessFlags(MBB);
     }
 
-
     // Remove any implicit kills that are no longer valid.
     for (MachineInstr *MI : NewInstrs) {
       // Iterate backwards as we are removing operands as we go along.
@@ -287,7 +289,8 @@ bool FixStackmapsSpillReloads::runOnMachineFunction(MachineFunction &MF) {
       for (; Imp != ImpEnd;) {
         Imp--;
         if (Imp->isReg() && Imp->isKill()) {
-          if (MBB.computeRegisterLiveness(TRI, Imp->getReg(), MI) == MachineBasicBlock::LivenessQueryResult::LQR_Live) {
+          if (MBB.computeRegisterLiveness(TRI, Imp->getReg(), MI) ==
+              MachineBasicBlock::LivenessQueryResult::LQR_Live) {
             MI->removeOperand(MI->getOperandNo(Imp));
           }
         }

--- a/llvm/test/CodeGen/X86/yk-stackmaps-fixspills-killedflags.mir
+++ b/llvm/test/CodeGen/X86/yk-stackmaps-fixspills-killedflags.mir
@@ -1,0 +1,75 @@
+# RUN: llc -mtriple=x86_64-- -stop-after fix-stackmaps-spill-reloads --yk-insert-stackmaps --yk-stackmap-spillreloads-fix %s -o - | FileCheck %s
+
+# Check that we properly recompute register liveness flags after moving around
+# stackmap instructions in the `FixStackmapsSpillReloads` pass.
+# A scenario where this can happen is the following:
+#
+#   CALL @foo
+#   mov rax, killed rcx
+#   STACKMAP rax, rbx
+#
+# After the pass this would become:
+#
+#   CALL @foo
+#   STACKMAP killed rcx, rbx
+#   mov rax, killed rcx
+#
+# This is incorrect as we have copied over the `killed` flags when updating
+# the stackmap operands. To avoid this, the pass now runs the
+# `recomputeLivenessFlags` function on any machine block we've changed.
+#
+# We also check that `implicit kill`s are removed from stackmaps, when they are
+# no longer valid.
+#
+# Lastly, we check that loads from the stack that aren't actual spills, are
+# replaced with the constant `0xdead` (57005).
+
+# CHECK-LABEL: bb.0:
+# CHECK-LABEL: STACKMAP 1, 0, $rcx, 3, 3
+# CHECK-NEXT: $rax = MOV64rr killed $rcx
+# CHECK-LABEL: STACKMAP 2, 0, $rdx, 3
+# CHECK-NEXT: dead $rbx = MOV64rr killed $rdx
+# CHECK-LABEL: STACKMAP 3, 0, 2, 57005, 3, 3
+
+name: main
+tracksRegLiveness: true
+frameInfo:
+  hasStackMap:     true
+  stackSize:       24
+stack:
+  - { id: 0, type: spill-slot, offset: -8, size: 8, alignment: 8 }
+  - { id: 1, type: spill-slot, offset: -16, size: 8, alignment: 8 }
+  - { id: 2, type: spill-slot, offset: -24, size: 8, alignment: 8 }
+fixedStack:
+  - { id: 3, type: default, offset: 16, size: 4, alignment: 8 }
+body: |
+  bb.0:
+    successors: %bb.1
+    $rbp = frame-setup MOV64rr $rsp
+    $rcx = MOV64rm $rbp, 1, $noreg, -8, $noreg :: (load (s64) from %stack.0)
+    $rdx = MOV64rm $rbp, 1, $noreg, -16, $noreg :: (load (s64) from %stack.1)
+    JMP_1 %bb.1
+
+  bb.1:
+  ; predecessors: %bb.0, %bb.2
+    liveins: $rcx, $rdx
+    CALL64pcrel32 @main
+    $rax = MOV64rr $rcx
+    STACKMAP 1, 0, killed $rcx, 3
+    JMP_1 %bb.2
+
+  bb.2:
+  ; predecessors: %bb.0, %bb.2
+    liveins: $rdx, $rdx
+    CALL64pcrel32 @main
+    $rbx = MOV64rr killed $rdx
+    STACKMAP 2, 0, $rbx, 3, implicit killed $rbx
+    JMP_1 %bb.3
+
+  bb.3:
+  ; predecessors: %bb.2
+    liveins: $rax
+    CALL64pcrel32 @main
+    renamable $r10d = MOV32rm $rbp, 1, $noreg, 16, $noreg :: (load (s32) from %fixed-stack.3)
+    STACKMAP 3, 0, $r10d, 3
+    RET64 $rax

--- a/yk_format_new_files.sh
+++ b/yk_format_new_files.sh
@@ -13,7 +13,7 @@
 
 set -e
 
-YK_DIRS="./clang/test/Yk ./llvm/lib/Transforms/Yk ./llvm/include/llvm/Transforms/Yk llvm/lib/YkIR"
+YK_DIRS="./clang/test/Yk ./llvm/lib/Transforms/Yk ./llvm/include/llvm/Transforms/Yk llvm/lib/YkIR ./llvm/lib/CodeGen/Yk"
 
 if ./build/bin/clang-format -version > /dev/null 2>&1; then
     clang_format=./build/bin/clang-format


### PR DESCRIPTION
The `FixStackmapsSpillReloads` moves stackmap instructions back to the
call instruction they belong to, after the register allocator has
inserted spill reloads inbetween.

When doing so, we didn't update `kill` flags or removed tracked
registers from the stackmap that were no longer valid. This has been
fixed and we now run the verifier on any changes we made to make sure
they are sane.