### PR TITLE
Fix a conflicting stack deopt in db.lua.

### DIFF
--- a/llvm/lib/Target/X86/X86AsmPrinter.cpp
+++ b/llvm/lib/Target/X86/X86AsmPrinter.cpp
@@ -192,8 +192,9 @@ void processInstructions(
         }
         SpillMap[DwReg].insert(Offset);
       }
-      // YKOPT: we can also remove killed registers, if any.
-      // Check other places that have a `continue` too.
+      if (MO.isKill()) {
+        killRegister(DwReg, SpillMap);
+      }
       continue;
     }
 
@@ -209,6 +210,8 @@ void processInstructions(
         clearRhs(DwReg, SpillMap);
         SpillMap[DwReg] = {Offset};
       }
+      // Can it happen? (it'd be a dead load).
+      assert(!Lhs.isKill());
       continue;
     }
 


### PR DESCRIPTION
We had this deopt scenario:

  rbp range: -44..-40, val: 0x00000001
  rbp range: -48..-40, val: 0x00000004

The reason for this was we were failing to kill the rbp-48 deopt after the register it was associated with was killed, and a future stackmap was tracking the rbp-44 range that overlapped with the zombie range.