### PR TITLE
Fix a bug in indirect stackmap extra locations.

### DIFF
--- a/llvm/lib/CodeGen/StackMaps.cpp
+++ b/llvm/lib/CodeGen/StackMaps.cpp
@@ -258,9 +258,7 @@ StackMaps::parseOperand(MachineInstr::const_mop_iterator MOI,
       for (auto [TrackReg, Extras]: SpillOffsets) {
         for (auto E : Extras) {
           if (E == Imm) {
-            const TargetRegisterClass *RC = TRI->getMinimalPhysRegClass(Reg);
-            Locs.emplace_back(Location::Register, TRI->getSpillSize(*RC), TrackReg,
-                              0, Extras);
+            Locs.emplace_back(Location::Register, Size, TrackReg, 0, Extras);
             return ++MOI;
           }
         }


### PR DESCRIPTION
We record some memory spills as being the size of the register that we are addressing relative to. This is incorrect.

Fixes db.lua in HWT debug mode, where the deopt checker was catching this in the form of an overlapping deopt (because the size was twice what it should be).