### PR TITLE
SWT module clone support for control point transition.

### DIFF
--- a/llvm/include/llvm/Transforms/Yk/BasicBlockTracer.h
+++ b/llvm/include/llvm/Transforms/Yk/BasicBlockTracer.h
@@ -3,11 +3,16 @@
 
 #include "llvm/Pass.h"
 
-// The name of the trace function
+// The name of the trace function - used in swt tracing.
 #define YK_TRACE_FUNCTION "__yk_trace_basicblock"
 
+// The name of the dummy (noop) trace function - used in multi-module swt
+// tracing.
+#define YK_TRACE_FUNCTION_DUMMY "__yk_trace_basicblock_dummy"
+
 namespace llvm {
-ModulePass *createYkBasicBlockTracerPass();
+
+ModulePass *createYkBasicBlockTracerPass(bool YkModuleClone);
 } // namespace llvm
 
 #endif

--- a/llvm/include/llvm/Transforms/Yk/ModuleClone.h
+++ b/llvm/include/llvm/Transforms/Yk/ModuleClone.h
@@ -3,9 +3,17 @@
 
 #include "llvm/Pass.h"
 
-#define YK_UNOPT_PREFIX "__yk_unopt_"
-#define YK_UNOPT_MAIN "__yk_unopt_main"
-#define YK_CLONE_MODULE_CP_COUNT 2
+// The prefix for unoptimised functions.
+#define YK_SWT_UNOPT_PREFIX "__yk_unopt_"
+
+// The name of the unoptimised main function.
+#define YK_SWT_UNOPT_MAIN "__yk_unopt_main"
+
+// The name of the metadata indicating that a function is address-taken.
+#define YK_SWT_MODCLONE_FUNC_ADDR_TAKEN "__yk_func_addr_taken"
+
+// The number of expected control points in the module.
+#define YK_SWT_MODCLONE_CP_COUNT 2
 
 namespace llvm {
 ModulePass *createYkModuleClonePass();

--- a/llvm/include/llvm/Transforms/Yk/Stackmaps.h
+++ b/llvm/include/llvm/Transforms/Yk/Stackmaps.h
@@ -4,7 +4,7 @@
 #include "llvm/Pass.h"
 
 namespace llvm {
-ModulePass *createYkStackmapsPass(uint64_t stackmapIDStart);
+ModulePass *createYkStackmapsPass(uint64_t StackmapIDStart);
 } // namespace llvm
 
 #endif

--- a/llvm/lib/CodeGen/TargetPassConfig.cpp
+++ b/llvm/lib/CodeGen/TargetPassConfig.cpp
@@ -1144,9 +1144,9 @@ bool TargetPassConfig::addISelPasses() {
   
   // Default number of control points in a module.
   int numberOfControlPoints = 1;
-
   if (YkModuleClone) {
-    numberOfControlPoints = YK_CLONE_MODULE_CP_COUNT;
+    assert(YkBasicBlockTracer && "YkModuleClone requires YkShadowStackOpt");
+    numberOfControlPoints = YK_SWT_MODCLONE_CP_COUNT;
     addPass(createYkModuleClonePass());
   }
 
@@ -1203,7 +1203,7 @@ bool TargetPassConfig::addISelPasses() {
   }
 
   if (YkBasicBlockTracer) {
-    addPass(createYkBasicBlockTracerPass());
+    addPass(createYkBasicBlockTracerPass(YkModuleClone));
   }  
 
   addISelPrepare();

--- a/llvm/lib/CodeGen/Yk/FixStackmapsSpillReloads.cpp
+++ b/llvm/lib/CodeGen/Yk/FixStackmapsSpillReloads.cpp
@@ -110,10 +110,12 @@ bool FixStackmapsSpillReloads::runOnMachineFunction(MachineFunction &MF) {
             MI.getOpcode() != TargetOpcode::PATCHPOINT) {
           MachineOperand Op = MI.getOperand(0);
           if (Op.isGlobal() &&
-              Op.getGlobal()->getGlobalIdentifier() == YK_TRACE_FUNCTION) {
-            // `YK_TRACE_FUNCTION` calls don't require stackmaps so we don't
-            // need to adjust anything here. In fact, doing so will skew any
-            // stackmap that follows.
+              (Op.getGlobal()->getGlobalIdentifier() == YK_TRACE_FUNCTION ||
+               Op.getGlobal()->getGlobalIdentifier() ==
+                   YK_TRACE_FUNCTION_DUMMY)) {
+            // `YK_TRACE_FUNCTION` and `YK_TRACE_FUNCTION_DUMMY` calls don't
+            // require stackmaps so we don't need to adjust anything here. In
+            // fact, doing so will skew any stackmap that follows.
             continue;
           }
           // If we see a normal function call we know it will be followed by a

--- a/llvm/lib/Transforms/Yk/ShadowStack.cpp
+++ b/llvm/lib/Transforms/Yk/ShadowStack.cpp
@@ -372,11 +372,10 @@ public:
     // If we have two control points, we need to update the cloned main
     // function as well.
     if (controlPointCount == 2) {
-      Function *UnoptMain = M.getFunction(YK_UNOPT_MAIN);
+      Function *UnoptMain = M.getFunction(YK_SWT_UNOPT_MAIN);
       if (UnoptMain == nullptr || UnoptMain->isDeclaration()) {
-        Context.emitError(
-            "Unable to add shadow stack: could not find definition "
-            "of \"__yk_unopt_main\" function!");
+        Context.emitError("Unable to add shadow stack: could not find "
+                          "definition " YK_SWT_UNOPT_MAIN " function!");
         return;
       }
 
@@ -462,7 +461,7 @@ public:
         continue;
       }
       // skip already handled main and unopt functions
-      if (F.getName() == MAIN || F.getName() == YK_UNOPT_MAIN) {
+      if (F.getName() == MAIN || F.getName() == YK_SWT_UNOPT_MAIN) {
         continue;
       }
       // skip functions that will never be traced.

--- a/llvm/lib/Transforms/Yk/StackMaps.cpp
+++ b/llvm/lib/Transforms/Yk/StackMaps.cpp
@@ -57,8 +57,6 @@ public:
     for (Function &F : M) {
       if (F.empty()) // skip declarations.
         continue;
-      if (F.getName().startswith(YK_UNOPT_PREFIX)) // skip cloned functions
-        continue;
       if (F.hasFnAttribute("yk_outline") && !(containsControlPoint(F))) {
         continue;
       }

--- a/llvm/lib/YkIR/YkIRWriter.cpp
+++ b/llvm/lib/YkIR/YkIRWriter.cpp
@@ -20,6 +20,7 @@
 #include "llvm/MC/MCContext.h"
 #include "llvm/MC/MCSectionELF.h"
 #include "llvm/MC/MCStreamer.h"
+#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Transforms/Yk/ControlPoint.h"
 #include "llvm/Transforms/Yk/Idempotent.h"
@@ -1952,20 +1953,13 @@ public:
     // Count functions for serilaisation and populate functions map
     int functionCount = 0;
     for (llvm::Function &F : M) {
-      // Skip cloned functions
-      if (!StringRef(F.getName()).startswith(YK_UNOPT_PREFIX)) {
-        FunctionIndexMap[&F] = functionCount;
-        functionCount++;
-      }
+      FunctionIndexMap[&F] = functionCount;
+      functionCount++;
     }
     // Emit the number of functions
     OutStreamer.emitSizeT(functionCount);
     // funcs:
     for (llvm::Function &F : M) {
-      // Skip cloned functions
-      if (StringRef(F.getName()).startswith(YK_UNOPT_PREFIX)) {
-        continue;
-      }
       serialiseFunc(F);
     }
 

--- a/llvm/test/Transforms/Yk/ModuleClone.ll
+++ b/llvm/test/Transforms/Yk/ModuleClone.ll
@@ -76,14 +76,14 @@ entry:
 ; Check original function: inc
 ; CHECK-LABEL: define dso_local i32 @inc(i32 %x)
 ; CHECK-NEXT: entry:
-; CHECK-NEXT: call void @__yk_trace_basicblock({{.*}})
+; CHECK-NEXT: call void @__yk_trace_basicblock_dummy({{.*}})
 ; CHECK-NEXT: %0 = add i32 %x, 1
 ; CHECK-NEXT: ret i32 %0
 
 ; Check original function: my_func
 ; CHECK-LABEL: define dso_local i32 @my_func(i32 %x)
 ; CHECK-NEXT: entry:
-; CHECK-NEXT: call void @__yk_trace_basicblock({{.*}})
+; CHECK-NEXT: call void @__yk_trace_basicblock_dummy({{.*}})
 ; CHECK-NEXT: %0 = add i32 %x, 1
 ; CHECK-NEXT: %func_ptr = alloca ptr, align 8
 ; CHECK-NEXT: store ptr @func_inc_with_address_taken, ptr %func_ptr, align 8
@@ -94,7 +94,7 @@ entry:
 ; Check original function: main
 ; CHECK-LABEL: define dso_local i32 @main()
 ; CHECK-NEXT: entry:
-; CHECK-NEXT: call void @__yk_trace_basicblock({{.*}})
+; CHECK-NEXT: call void @__yk_trace_basicblock_dummy({{.*}})
 ; CHECK-NEXT: %0 = call i32 @my_func(i32 10)
 ; CHECK-NEXT: %1 = load i32, ptr @my_global
 ; CHECK-NEXT: %2 = call i32 (ptr, ...) @printf


### PR DESCRIPTION
- Introduce `__yk_trace_basicblock_dummy` (no-op) alongside existing `__yk_trace_basicblock` calls.
  - Optimised functions: Use __yk_trace_basicblock_dummy` calls since they're not executed during tracing phase
  - Unoptimized + address-taken functions: Use __yk_trace_basicblock` calls since they may execute during tracing
- Serialise both unopt and opt functions in `YkIRWriter.cpp` if `YkModuleClone` flag is set.