### PR TITLE
Disable unsound deopt optimisation.

### DIFF
--- a/llvm/lib/CodeGen/StackMaps.cpp
+++ b/llvm/lib/CodeGen/StackMaps.cpp
@@ -324,17 +324,9 @@ StackMaps::parseOperand(MachineInstr::const_mop_iterator MOI,
     if (MOI->isReg()) {
       if (SpillOffsets.count(DwarfRegNum) > 0) {
         Extras = SpillOffsets[DwarfRegNum];
-        // Remove redundant registers/offsets that are already tracked by the
-        // stackmap or by another tracked register.
-        for (auto TReg : TrackedRegisters) {
-          if (TReg == DwarfRegNum) {
-            continue;
-          }
-          Extras.erase(TReg);
-          for (auto X : SpillOffsets[TReg]) {
-            Extras.erase(X);
-          }
-        }
+        // YKOPT: We could eliminate duplicate deopts here to take pressure off
+        // the runtime deopt routine. There is an (unsound) attempt at this in
+        // the git history (it killed too many memory deopts).
       }
     }
 


### PR DESCRIPTION
I've tracked the LuLPeg failures down to this optimisation.

The optimisation is supposed to remove duplicate deoptimisations so as to avoid doing unnecessary work at runtime in the deopt routine, however, it appears to delete memory optimisations required for soundness.

This manifested in LuLPeg as follows:

 - LEN opcode is used to put the length of a table onto the Lua stack.
 - FORPREP opcode is supposed to pick up the result of the LEN opcode for the loop's "limit".

But:

 - There is a deopt in the middle of the LEN opcode that (due to the bogus optimisation) fails to flush the result back to the Lua stack, leaving a `nil` on the Lua stack.
 - FORPREP quite rightly gets upset that `nil` isn't a valid loop limit.

At the ykllvm level the input to the optimisation is (reg -> extras):

 - rdx -> [r15, rbp-48]
 - r15 -> [rdx, rbp-48]

And rbp-48 is where the result of LEN should be written by deopt, but the optimisation erroneously deletes it, so it never makes it into the stackmap.

Whilst this optimisation could be fixed, rather than disabling it, since LuLPeg has been failing for so long, I'd rather restore soundness first (and look the performance impact too). Soundness is King.