### PR TITLE
Don't consider "address taken" functions to automatically be traceable.

### DIFF
--- a/llvm/lib/Transforms/Yk/OutlineUntraceable.cpp
+++ b/llvm/lib/Transforms/Yk/OutlineUntraceable.cpp
@@ -120,12 +120,6 @@ private:
       return false;
     }
 
-    if (F->hasAddressTaken()) {
-      // Address is taken. All bets are off because the function could be
-      // indirectly called from inside (or outside) of the module.
-      return true;
-    }
-
     // We've checked all the easy stuff, now we have to inspect the call graph.
     // If there exists at least one direct-call path from the control point to
     // F, then F may be traced, otherwise it can't.


### PR DESCRIPTION
This is an evolving heuristic, and we're probably going to refine this further but for now it seems that we're better off being conservative with "should we consider this function as traceable or not". Just because a function has its address taken does not mean that it will end up in a trace; right now, at least in yklua, doing so makes performance noticeably worse. Note: this is not a correctness issue. It is purely related to performance.