### PR TITLE
Don't insert shadow frames for functions that can't be traced.

### DIFF
--- a/llvm/lib/CodeGen/TargetPassConfig.cpp
+++ b/llvm/lib/CodeGen/TargetPassConfig.cpp
@@ -1163,6 +1163,10 @@ bool TargetPassConfig::addISelPasses() {
     addPass(createYkNoCallsInEntryBlocksPass());
   }
 
+  if (YkOutlineUntraceable) {
+    addPass(createOutlineUntraceablePass());
+  }
+
   if (YkShadowStackOpt) {
     addPass(createYkShadowStackPass(numberOfControlPoints));
   }
@@ -1183,14 +1187,6 @@ bool TargetPassConfig::addISelPasses() {
 
   if (YkLinkage) {
     addPass(createYkLinkagePass());
-  }
-
-  if (YkOutlineUntraceable) {
-    // FIXME: I think we should be able to run this earlier (before the
-    // YkBlockDisambiguate pass) to benefit from it even more, but it causes
-    // crashes. Also, are there any other Yk passes above that could, but don't
-    // yet, skip functions marked yk_outline? Investigate.
-    addPass(createOutlineUntraceablePass());
   }
 
   if (YkPatchIdempotent) {


### PR DESCRIPTION
If a function can't be traced, there's no need for it to have a shadow stack, which in theory means that we can avoid the runtime cost of allocating/freeing shadow stack space and reads/write to the shadow stack.

Implementing this is just a matter of making the "outline untraceable" pass earlier.

However, doing so resulted in seg faults due to the shadow stack pointer not being restored properly after a longjmp(). Hence this change also contains a fix that loads/restores the shadow stack pointer before/after a setjmp() or similar.

Performance impact is a bit of a mixed bag. revcomp speeds up about 11%, but towers slows down about 5% (the latter I checked manually, and this slowdown is real).

Because this fixes a soundness issue, I think we can move forward.

```
Datum1: before-sstack-fix
Datum0: after-sstack-fix

 Benchmark                  Datum1 (ms)  Datum0 (ms)  Ratio  Summary
 revcomp/YkLua/default      472          417          0.88   11.64% faster
 Permute/YkLua/1000         791          758          0.96   4.17% faster
 fasta/YkLua/500000         385          372          0.97   3.44% faster
 Bounce/YkLua/1500          904          878          0.97   2.93% faster
 Sieve/YkLua/3000           453          445          0.98   1.81% faster
 HashIds/YkLua/6000         1217         1204         0.99   1.01% faster
 binarytrees/YkLua/15       1325         1312         0.99   1.00% faster
 Storage/YkLua/1000         3933         3895         0.99   0.96% faster
 Heightmap/YkLua/2000       737          733          0.99   0.52% faster
 knucleotide/YkLua/default  1542         1537         1.00   0.36% faster
 CD/YkLua/250               3958         3946         1.00   0.30% faster
 Richards/YkLua/100         4143         4134         1.00   0.23% faster
 spectralnorm/YkLua/1000    895          894          1.00   0.00% faster
 LuLPeg/YkLua/default       1476         1476         1.00   0.03% slower
 Mandelbrot/YkLua/500       126          126          1.00   0.04% slower
 NBody/YkLua/250000         466          467          1.00   0.20% slower
 Havlak/YkLua/1500          9578         9651         1.01   0.76% slower
 Json/YkLua/100             1504         1517         1.01   0.86% slower
 fannkuchredux/YkLua/10     1229         1241         1.01   0.98% slower
 DeltaBlue/YkLua/12000      1205         1222         1.01   1.37% slower
 BigLoop/YkLua/1000000000   2362         2395         1.01   1.39% slower
 Queens/YkLua/1000          460          476          1.03   3.47% slower
 List/YkLua/1500            753          788          1.05   4.62% slower
 Towers/YkLua/600           869          913          1.05   5.09% slower
```