### PR TITLE
Enable direct calls to address-taken functions from optimised functions

### DIFF
--- a/llvm/include/llvm/Transforms/Yk/ModuleClone.h
+++ b/llvm/include/llvm/Transforms/Yk/ModuleClone.h
@@ -6,11 +6,21 @@
 // The prefix for unoptimised functions.
 #define YK_SWT_UNOPT_PREFIX "__yk_unopt_"
 
+// The prefix for optimised functions.
+#define YK_SWT_OPT_PREFIX "__yk_opt_"
+
 // The name of the unoptimised main function.
 #define YK_SWT_UNOPT_MAIN "__yk_unopt_main"
 
 // The name of the metadata indicating that a function is address-taken.
 #define YK_SWT_MODCLONE_FUNC_ADDR_TAKEN "__yk_func_addr_taken"
+
+// The name of the metadata indicating that a function is unoptimised.
+#define YK_SWT_UNOPT_MD "__yk_unopt"
+ 
+// The name of the metadata indicating that a function is unoptimised.
+#define YK_SWT_OPT_MD "__yk_opt"
+
 
 // The number of expected control points in the module.
 #define YK_SWT_MODCLONE_CP_COUNT 2

--- a/llvm/lib/Transforms/Yk/BasicBlockTracer.cpp
+++ b/llvm/lib/Transforms/Yk/BasicBlockTracer.cpp
@@ -62,22 +62,12 @@ struct YkBasicBlockTracer : public ModulePass {
         builder.SetInsertPoint(&*BB.getFirstInsertionPt());
 
         if (ModuleClone) {
-          bool isUnopt = F.getName().startswith(YK_SWT_UNOPT_PREFIX);
-          bool isAddrTaken =
-              F.getMetadata(YK_SWT_MODCLONE_FUNC_ADDR_TAKEN) != nullptr;
-
-          if (isAddrTaken || isUnopt) {
-            // Address-taken functions and unoptimised functions need real trace
-            // calls that actually record execution.
-            // 1. Address-taken functions are not cloned in ModuleClone
-            //    pass but still have tracing calls inserted. There is only one
-            //    version for these functions: unopt (note that even though
-            //    these functions are unopt they do not have the unopt prefix).
-            // 2. Unoptimised functions (with __yk_unopt_ prefix) are the
-            //    cloned versions created by module cloning.
+          if (F.getMetadata(YK_SWT_UNOPT_MD) != nullptr) {
+            // Unoptimised functions need real trace calls that actually record execution.
             builder.CreateCall(TraceFunc, {builder.getInt32(FunctionIndex),
                                            builder.getInt32(BlockIndex)});
-          } else {
+          } 
+          if (F.getMetadata(YK_SWT_OPT_MD) != nullptr) {
             // Optimised functions (without __yk_unopt_ prefix and not
             // address-taken) get dummy trace calls because we don't execute
             // them during tracing.

--- a/llvm/test/Transforms/Yk/ModuleClone.ll
+++ b/llvm/test/Transforms/Yk/ModuleClone.ll
@@ -15,10 +15,24 @@ declare dso_local i32 @fprintf(ptr noundef, ptr noundef, ...)
 declare dso_local void @yk_location_drop(i64)
 declare dso_local void @yk_mt_shutdown(ptr noundef)
 
-define dso_local i32 @func_inc_with_address_taken(i32 %x) {
+define dso_local i32 @g_with_address_taken(i32 %x) {
 entry:
   %call = call i32 @inc(i32 %x)
   ret i32 %call
+}
+
+define dso_local i32 @f_with_address_taken(i32 %x) {
+entry:
+  %0 = add i32 %x, 1
+  %func_ptr = alloca ptr, align 8
+  store ptr @g_with_address_taken, ptr %func_ptr, align 8
+  %1 = load ptr, ptr %func_ptr, align 8
+  ; Indirect call to g_with_address_taken
+  %2 = call i32 %1(i32 42)
+  ; Direct call to g_with_address_taken
+  %3 = call i32 @g_with_address_taken(i32 %0)
+  %4 = add i32 %3, 2
+  ret i32 %2
 }
 
 define dso_local i32 @inc(i32 %x) {
@@ -31,9 +45,12 @@ define dso_local i32 @my_func(i32 %x) {
 entry:
   %0 = add i32 %x, 1
   %func_ptr = alloca ptr, align 8
-  store ptr @func_inc_with_address_taken, ptr %func_ptr, align 8
+  store ptr @f_with_address_taken, ptr %func_ptr, align 8
   %1 = load ptr, ptr %func_ptr, align 8
+  ; Indirect call to f_with_address_taken
   %2 = call i32 %1(i32 42)
+  ; Direct call to f_with_address_taken
+  %3 = call i32 @f_with_address_taken(i32 %0)
   ret i32 %2
 }
 
@@ -43,102 +60,119 @@ entry:
   %1 = load i32, ptr @my_global
   %2 = call i32 (ptr, ...) @printf(ptr @.str, i32 %1)
   ret i32 0
-}
+}; 
 
-; ======================================================================
-; Original functions - behavior depends on whether address is taken
-; ======================================================================
-; - Functions WITHOUT address taken: get dummy trace calls (optimized)
-; - Functions WITH address taken: get real trace calls (unoptimised) and
-;   call unoptimised versions of other functions when available
-; File header checks
 ; CHECK: source_filename = "ModuleClone.c"
 ; CHECK: target triple = "x86_64-pc-linux-gnu"
 
-; Global variable and string checks
-; CHECK: @.str = private unnamed_addr constant [13 x i8] c"Hello, world\00", align 1
-; CHECK: @my_global = global i32 42, align 4
-
-; Declaration checks
-; CHECK: declare i32 @printf(ptr, ...)
-; CHECK: declare dso_local ptr @yk_mt_new(ptr noundef)
-; CHECK: declare dso_local void @yk_mt_hot_threshold_set(ptr noundef, i32 noundef)
-; CHECK: declare dso_local i64 @yk_location_new()
-; CHECK: declare dso_local void @yk_mt_control_point(ptr noundef, ptr noundef)
-; CHECK: declare dso_local i32 @fprintf(ptr noundef, ptr noundef, ...)
-; CHECK: declare dso_local void @yk_location_drop(i64)
-; CHECK: declare dso_local void @yk_mt_shutdown(ptr noundef)
-
-; Check that func_inc_with_address_taken is present in its original form
-; Since address-taken functions are treated as unoptimised, they should call
-; the unoptimised versions of other functions when available
-; CHECK-LABEL: define dso_local i32 @func_inc_with_address_taken(i32 %x)
+; Verify that functions with addresses taken are marked as unoptimised and call unoptimised variants
+; CHECK-LABEL: define dso_local i32 @g_with_address_taken(i32 %x) !__yk_unopt !0 {
 ; CHECK-NEXT: entry:
-; CHECK-NEXT: call void @__yk_trace_basicblock({{.*}})
-; CHECK-NEXT: %call = call i32 @__yk_unopt_inc(i32 %x)
-; CHECK-NEXT: ret i32 %call
+; CHECK-NEXT:   call void @__yk_trace_basicblock(i32 8, i32 0)
+; CHECK-NEXT:   %call = call i32 @__yk_unopt_inc(i32 %x)
+; CHECK-NEXT:   ret i32 %call
+; CHECK-NEXT: }
+
+; Verify that address-taken functions preserve original call semantics whilst using unoptimised variants
+; CHECK-LABEL: define dso_local i32 @f_with_address_taken(i32 %x) !__yk_unopt !0 {
+; CHECK-NEXT: entry:
+; CHECK-NEXT:   call void @__yk_trace_basicblock(i32 9, i32 0)
+; CHECK-NEXT:   %0 = add i32 %x, 1
+; CHECK-NEXT:   %func_ptr = alloca ptr, align 8
+; CHECK-NEXT:   store ptr @g_with_address_taken, ptr %func_ptr, align 8
+; CHECK-NEXT:   %1 = load ptr, ptr %func_ptr, align 8
+; CHECK-NEXT:   %2 = call i32 %1(i32 42)
+; CHECK-NEXT:   %3 = call i32 @g_with_address_taken(i32 %0)
+; CHECK-NEXT:   %4 = add i32 %3, 2
+; CHECK-NEXT:   ret i32 %2
+; CHECK-NEXT: }
   
-; Check original function: inc
-; CHECK-LABEL: define dso_local i32 @inc(i32 %x)
+; Verify that optimised functions utilise dummy tracing calls rather than full tracing
+; CHECK-LABEL: define dso_local i32 @inc(i32 %x) !__yk_opt !0 {
 ; CHECK-NEXT: entry:
-; CHECK-NEXT: call void @__yk_trace_basicblock_dummy({{.*}})
-; CHECK-NEXT: %0 = add i32 %x, 1
-; CHECK-NEXT: ret i32 %0
-
-; Check original function: my_func
-; CHECK-LABEL: define dso_local i32 @my_func(i32 %x)
-; CHECK-NEXT: entry:
-; CHECK-NEXT: call void @__yk_trace_basicblock_dummy({{.*}})
-; CHECK-NEXT: %0 = add i32 %x, 1
-; CHECK-NEXT: %func_ptr = alloca ptr, align 8
-; CHECK-NEXT: store ptr @func_inc_with_address_taken, ptr %func_ptr, align 8
-; CHECK-NEXT: %1 = load ptr, ptr %func_ptr, align 8
-; CHECK-NEXT: %2 = call i32 %1(i32 42)
-; CHECK-NEXT: ret i32 %2
-
-; Check original function: main
-; CHECK-LABEL: define dso_local i32 @main()
-; CHECK-NEXT: entry:
-; CHECK-NEXT: call void @__yk_trace_basicblock_dummy({{.*}})
-; CHECK-NEXT: %0 = call i32 @my_func(i32 10)
-; CHECK-NEXT: %1 = load i32, ptr @my_global
-; CHECK-NEXT: %2 = call i32 (ptr, ...) @printf
-; CHECK-NEXT: ret i32 0
-
-; ======================================================================
-; Functions whose addresses are taken should not be cloned
-; ======================================================================
-; Functions with their addresses taken should not be cloned (to avoid updating
-; all function pointer references). However, they are treated as unoptimised
-; and have their internal calls updated to use unoptimised versions.
-; `func_inc_with_address_taken` is used by pointer and thus remains uncloned.
-; CHECK-NOT: define dso_local i32 @__yk_unopt_func_inc_with_address_taken
-
-; ======================================================================
-; Cloned functions - should have real trace calls and call other unoptimised functions
-; ======================================================================
-; Check cloned function: __yk_unopt_inc
-; CHECK-LABEL: define dso_local i32 @__yk_unopt_inc(i32 %x)
-; CHECK-NEXT: entry:
-; CHECK-NEXT: call void @__yk_trace_basicblock({{.*}})
-; CHECK-NEXT: %0 = add i32 %x, 1
-; CHECK-NEXT: ret i32 %0
-
-; Check cloned function: __yk_unopt_my_func
-; CHECK-LABEL: define dso_local i32 @__yk_unopt_my_func(i32 %x)
-; CHECK-NEXT: entry:
-; CHECK-NEXT: call void @__yk_trace_basicblock({{.*}})
-; CHECK-NEXT: %0 = add i32 %x, 1
-; CHECK-NEXT: %func_ptr = alloca ptr, align 8
-; CHECK-NEXT: store ptr @func_inc_with_address_taken, ptr %func_ptr, align 8
-; CHECK-NEXT: %1 = load ptr, ptr %func_ptr, align 8
-; CHECK-NEXT: %2 = call i32 %1(i32 42)
-; CHECK-NEXT: ret i32 %2
-
-; Check cloned function: __yk_unopt_main
-; CHECK-LABEL: define dso_local i32 @__yk_unopt_main()
-; CHECK-NEXT: entry:
-; CHECK-NEXT: call void @__yk_trace_basicblock({{.*}})
-; CHECK-NEXT: %0 = call i32 @__yk_unopt_my_func(i32 10)
-; CHECK-NEXT: %1 = load i32, ptr @my_global
-; CHECK-NEXT: %2 = call i32 (ptr, ...) @printf
+; CHECK-NEXT:   call void @__yk_trace_basicblock_dummy(i32 10, i32 0)
+; CHECK-NEXT:   %0 = add i32 %x, 1
+; CHECK-NEXT:   ret i32 %0
+; CHECK-NEXT: }
+  
+; Verify that optimised functions maintain original semantics for indirect calls (to address-taken functions)
+; whilst using optimised variants for direct calls
+; CHECK-LABEL: define dso_local i32 @my_func(i32 %x) !__yk_opt !0 {
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    call void @__yk_trace_basicblock_dummy(i32 11, i32 0)
+; CHECK-NEXT:    %0 = add i32 %x, 1
+; CHECK-NEXT:    %func_ptr = alloca ptr, align 8
+; CHECK-NEXT:    store ptr @f_with_address_taken, ptr %func_ptr, align 8
+; CHECK-NEXT:    %1 = load ptr, ptr %func_ptr, align 8
+; CHECK-NEXT:    %2 = call i32 %1(i32 42)
+; CHECK-NEXT:    %3 = call i32 @__yk_opt_f_with_address_taken(i32 %0)
+; CHECK-NEXT:    ret i32 %2
+; CHECK-NEXT:  }
+  
+; Verify that the main function is marked as optimised and uses dummy tracing
+; CHECK-LABEL: define dso_local i32 @main() !__yk_opt !0 {
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    call void @__yk_trace_basicblock_dummy(i32 12, i32 0)
+; CHECK-NEXT:    %0 = call i32 @my_func(i32 10)
+; CHECK-NEXT:    %1 = load i32, ptr @my_global, align 4
+; CHECK-NEXT:    %2 = call i32 (ptr, ...) @printf(ptr @.str, i32 %1)
+; CHECK-NEXT:    ret i32 0
+; CHECK-NEXT:  }
+  
+; Verify that optimised clones of address-taken functions utilise dummy tracing calls
+; CHECK-LABEL: define dso_local i32 @__yk_opt_g_with_address_taken(i32 %x) !__yk_opt !0
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    call void @__yk_trace_basicblock_dummy(i32 13, i32 0)
+; CHECK-NEXT:    %call = call i32 @inc(i32 %x)
+; CHECK-NEXT:    ret i32 %call
+; CHECK-NEXT:  }
+  
+; Verify that optimised clones preserve indirect call semantics (to original address-taken functions)
+; whilst using optimised variants for direct calls
+; CHECK-LABEL: define dso_local i32 @__yk_opt_f_with_address_taken(i32 %x) !__yk_opt !0
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    call void @__yk_trace_basicblock_dummy(i32 14, i32 0)
+; CHECK-NEXT:    %0 = add i32 %x, 1
+; CHECK-NEXT:    %func_ptr = alloca ptr, align 8
+; CHECK-NEXT:    store ptr @g_with_address_taken, ptr %func_ptr, align 8
+; CHECK-NEXT:    %1 = load ptr, ptr %func_ptr, align 8
+; CHECK-NEXT:    %2 = call i32 %1(i32 42)
+; CHECK-NEXT:    %3 = call i32 @__yk_opt_g_with_address_taken(i32 %0)
+; CHECK-NEXT:    %4 = add i32 %3, 2
+; CHECK-NEXT:    ret i32 %2
+; CHECK-NEXT:  }
+  
+; Verify that unoptimised clones have real tracing calls
+; CHECK-LABEL: define dso_local i32 @__yk_unopt_inc(i32 %x) !__yk_unopt !0 {
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    call void @__yk_trace_basicblock(i32 15, i32 0)
+; CHECK-NEXT:    %0 = add i32 %x, 1
+; CHECK-NEXT:    ret i32 %0
+; CHECK-NEXT:  }
+  
+; Verify that unoptimised clones call original address-taken functions for both direct and indirect calls
+; CHECK-LABEL: define dso_local i32 @__yk_unopt_my_func(i32 %x) !__yk_unopt !0 {
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    call void @__yk_trace_basicblock(i32 16, i32 0)
+; CHECK-NEXT:    %0 = add i32 %x, 1
+; CHECK-NEXT:    %func_ptr = alloca ptr, align 8
+; CHECK-NEXT:    store ptr @f_with_address_taken, ptr %func_ptr, align 8
+; CHECK-NEXT:    %1 = load ptr, ptr %func_ptr, align 8
+; CHECK-NEXT:    %2 = call i32 %1(i32 42)
+; CHECK-NEXT:    %3 = call i32 @f_with_address_taken(i32 %0)
+; CHECK-NEXT:    ret i32 %2
+; CHECK-NEXT:  }
+  
+; Verify that unoptimised main function calls unoptimised variants and uses real tracing calls.
+; CHECK-LABEL: define dso_local i32 @__yk_unopt_main() !__yk_unopt !0 {
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    call void @__yk_trace_basicblock(i32 17, i32 0)
+; CHECK-NEXT:    %0 = call i32 @__yk_unopt_my_func(i32 10)
+; CHECK-NEXT:    %1 = load i32, ptr @my_global, align 4
+; CHECK-NEXT:    %2 = call i32 (ptr, ...) @printf(ptr @.str, i32 %1)
+; CHECK-NEXT:    ret i32 0
+; CHECK-NEXT:  }
+  
+; Verify that the required tracing function declarations are present in the output
+; CHECK-LABEL: declare void @__yk_trace_basicblock(i32, i32)  
+; CHECK-LABEL: declare void @__yk_trace_basicblock_dummy(i32, i32)


### PR DESCRIPTION
This change introduces another function clone with the prefix __yk_opt for address-taken functions, enabling optimised functions to call optimised versions directly.

Changes:
- Address-taken functions now get two versions: original (unoptimised with real tracing calls) and __yk_opt_ clone (optimised with dummy tracing calls)
- Non-address-taken functions keep existing behavior: original (optimised with dummy calls) and __yk_unopt_ clone (unoptimised with real calls)
- BasicBlockTracer uses metadata (__yk_opt/__yk_unopt) instead of name prefixes
- Indirect calls always target original address-taken functions to preserve function pointer semantics

This allows optimised code paths to avoid the overhead of real tracing calls when calling address-taken functions directly.


 :point_right:  Followup from this [comment](https://github.com/ykjit/ykllvm/pull/269#issuecomment-3183950657)


## Benchmarks

| Benchmark | `yklua/main` (ms) | `yklua/call-opt-functions-from-opt-context` (ms) | Ratio | Summary |
|-----------|-------------------|---------------------------------------------------|-------|---------|
| NBody/YkLuaMulti/250000 | 514 | 480 | 0.93 | 6.76% faster |
| Queens/YkLuaMulti/1000 | 474 | 444 | 0.94 | 6.14% faster |
| Sieve/YkLuaMulti/3000 | 612 | 596 | 0.97 | 2.64% faster |
| List/YkLuaMulti/1500 | 808 | 796 | 0.99 | 1.43% faster |
| Richards/YkLuaMulti/100 | 4113 | 4058 | 0.99 | 1.33% faster |
| Storage/YkLuaMulti/1000 | 3012 | 2982 | 0.99 | 0.99% faster |
| Permute/YkLuaMulti/1000 | 852 | 844 | 0.99 | 0.87% faster |
| Havlak/YkLuaMulti/1500 | 8175 | 8110 | 0.99 | 0.80% faster |
| DeltaBlue/YkLuaMulti/12000 | 1105 | 1101 | 1.00 | 0.33% faster |
| Json/YkLuaMulti/100 | 1351 | 1347 | 1.00 | 0.28% faster |
| CD/YkLuaMulti/250 | 3591 | 3583 | 1.00 | 0.21% faster |
| Mandelbrot/YkLuaMulti/500 | 128 | 129 | 1.01 | 1.06% slower |
| Bounce/YkLuaMulti/1500 | 886 | 897 | 1.01 | 1.17% slower |
| Towers/YkLuaMulti/600 | 916 | 945 | 1.03 | 3.23% slower |