### PR TITLE
Run ISel and backend optimisations on optimised clones.

### DIFF
--- a/clang/test/Yk/yk_stackmapspillreloads_bug.c
+++ b/clang/test/Yk/yk_stackmapspillreloads_bug.c
@@ -1,4 +1,4 @@
-// RUN: %clang -flto -Xclang -disable-O0-optnone -fuse-ld=lld -Wl,--mllvm=--yk-stackmap-spillreloads-fix -Wl,--mllvm=--yk-insert-stackmaps -Wl,--mllvm=--yk-optnone-after-ir-passes -Wl,--lto-newpm-passes=instcombine -Wl,--mllvm=--yk-shadow-stack %s
+// RUN: %clang -flto -Xclang -disable-O0-optnone -fuse-ld=lld -Wl,--mllvm=--yk-stackmap-spillreloads-fix -Wl,--mllvm=--yk-insert-stackmaps -Wl,--mllvm=--yk-mark-traceable-optnone-after-ir-passes -Wl,--lto-newpm-passes=instcombine -Wl,--mllvm=--yk-shadow-stack %s
 
 // Test case scenario extracted from CPython source code: license at
 // https://github.com/python/cpython/blob/main/LICENSE.

--- a/llvm/include/llvm/Support/Yk.h
+++ b/llvm/include/llvm/Support/Yk.h
@@ -7,7 +7,7 @@ void initYkOptions(void);
 
 // YKFIXME: all of our command-line arguments should be collected here instead
 // of us randomly introducing `extern bool`s all over the place.
-extern bool YkOptNoneAfterIRPasses;
+extern bool YkMarkTraceableOptNone;
 extern bool YkDontOptFuncABI;
 extern bool YkPatchCtrlPoint;
 extern bool YkPatchIdempotent;

--- a/llvm/include/llvm/Transforms/Yk/MarkTraceableOptNone.h
+++ b/llvm/include/llvm/Transforms/Yk/MarkTraceableOptNone.h
@@ -1,0 +1,10 @@
+#ifndef LLVM_TRANSFORMS_YK_MARKTRACEABLEOPTNONE_H
+#define LLVM_TRANSFORMS_YK_MARKTRACEABLEOPTNONE_H
+
+#include "llvm/Pass.h"
+
+namespace llvm {
+ModulePass *createYkMarkTraceableOptNonePass();
+} // namespace llvm
+
+#endif

--- a/llvm/lib/LTO/LTOBackend.cpp
+++ b/llvm/lib/LTO/LTOBackend.cpp
@@ -520,20 +520,6 @@ Error lto::backend(const Config &C, AddStreamFn AddStream,
       return Error::success();
   }
 
-  // Yk can't tolerate backend optimisations, so we mark every function that
-  // *could* be traced with `optnone` from here onwards. Note that `noinline`
-  // is a required prerequisite of `optnone`.
-  if (YkOptNoneAfterIRPasses) {
-    for (Function &F: Mod) {
-      if (!F.isDeclaration() &&
-          (!F.hasFnAttribute("yk_outline") || containsControlPoint(F)))
-      {
-        F.addFnAttr(Attribute::OptimizeNone);
-        F.addFnAttr(Attribute::NoInline);
-      }
-    }
-  }
-
   if (ParallelCodeGenParallelismLevel == 1) {
     codegen(C, TM.get(), AddStream, 0, Mod, CombinedIndex);
   } else {

--- a/llvm/lib/Support/Yk.cpp
+++ b/llvm/lib/Support/Yk.cpp
@@ -67,20 +67,20 @@ static ManagedStatic<cl::opt<bool, true>,
                      CreateYkStackmapsSpillReloadsFixParser>
     YkStackmapsSpillFixParser;
 
-bool YkOptNoneAfterIRPasses;
+bool YkMarkTraceableOptNone;
 namespace {
-struct CreateYkOptNoneAfterIRPassesParser {
+struct CreateYkMarkTraceableOptNoneParser {
   static void *call() {
     return new cl::opt<bool, true>(
-        "yk-optnone-after-ir-passes",
+        "yk-mark-traceable-optnone-after-ir-passes",
         cl::desc(
-            "Apply `optnone` to all functions prior to instruction selection."),
-        cl::NotHidden, cl::location(YkOptNoneAfterIRPasses));
+            "Apply `optnone` to all traceable functions prior to instruction selection."),
+        cl::NotHidden, cl::location(YkMarkTraceableOptNone));
   }
 };
 } // namespace
 static ManagedStatic<cl::opt<bool, true>,
-  CreateYkOptNoneAfterIRPassesParser> YkOptNoneAfterIRPassesParser;
+  CreateYkMarkTraceableOptNoneParser> YkMarkTraceableOptNoneParser;
 
 bool YkEmbedIR;
 namespace {
@@ -154,7 +154,7 @@ void llvm::initYkOptions() {
   *YkStackMapOffsetFixParser;
   *YkStackMapAdditionalLocsParser;
   *YkStackmapsSpillFixParser;
-  *YkOptNoneAfterIRPassesParser;
+  *YkMarkTraceableOptNoneParser;
   *YkEmbedIRParser;
   *YkDontOptFuncABIParser;
   *YkPatchCtrlPointParser;

--- a/llvm/lib/Transforms/Yk/CMakeLists.txt
+++ b/llvm/lib/Transforms/Yk/CMakeLists.txt
@@ -11,6 +11,7 @@ add_llvm_component_library(LLVMYkPasses
   SplitBlocksAfterCalls.cpp
   BasicBlockTracer.cpp
   ModuleClone.cpp
+  MarkTraceableOptNone.cpp
 
   DEPENDS
   intrinsics_gen

--- a/llvm/lib/Transforms/Yk/MarkTraceableOptNone.cpp
+++ b/llvm/lib/Transforms/Yk/MarkTraceableOptNone.cpp
@@ -1,0 +1,60 @@
+//===- MarkTraceableOptNone.cpp - Add `optnone` for the Yk JIT ---------===//
+//
+// This pass marks functions which could be traced with the `optnone` function
+// attribute just before instruction selection begins. This is because yk can't
+// get deal with functions that are isel/backend optimised.
+
+#include "llvm/Transforms/Yk/MarkTraceableOptNone.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/Module.h"
+#include "llvm/InitializePasses.h"
+#include "llvm/Pass.h"
+#include "llvm/Transforms/Yk/ControlPoint.h"
+#include "llvm/Transforms/Yk/ModuleClone.h"
+#include "llvm/YkIR/YkIRWriter.h"
+
+#define DEBUG_TYPE "yk-mark-traceable-optnone"
+
+using namespace llvm;
+
+namespace llvm {
+void initializeYkMarkTraceableOptNonePass(PassRegistry &);
+} // namespace llvm
+
+namespace {
+class YkMarkTraceableOptNone : public ModulePass {
+public:
+  static char ID;
+  YkMarkTraceableOptNone() : ModulePass(ID) {
+    initializeYkMarkTraceableOptNonePass(*PassRegistry::getPassRegistry());
+  }
+
+  bool runOnModule(Module &M) override {
+    bool Changed = false;
+    for (Function &F : M) {
+      if (F.getMetadata(YK_SWT_OPT_MD)) {
+        continue;
+      }
+      if ((F.hasFnAttribute(YK_OUTLINE_FNATTR)) && (!containsControlPoint(F))) {
+        continue;
+      }
+      if (F.isDeclaration()) {
+        continue;
+      }
+
+      F.addFnAttr(Attribute::OptimizeNone);
+      F.addFnAttr(Attribute::NoInline);
+      Changed = true;
+    }
+    return Changed;
+  }
+};
+} // namespace
+
+char YkMarkTraceableOptNone::ID = 0;
+INITIALIZE_PASS(YkMarkTraceableOptNone, DEBUG_TYPE, "yk-markoptnone", false,
+                false)
+
+ModulePass *llvm::createYkMarkTraceableOptNonePass() {
+  return new YkMarkTraceableOptNone();
+}


### PR DESCRIPTION
Before we added `optnone` to every function before instruction selection and the backend ran.

This change makes it so we only add `optnone` to things that could be traced.

This means that things marked yk_outline and optimised clone functions do not get marked `optnone`, so in theory they should benefit from a handful of optimisations that they didn't before.

Looks like it might speed us up a few percent, but nothing dramatic.