### PR TITLE
Move module cloner earlier to allow more AOT inlining of optimised clones

### DIFF
--- a/.buildbot_dockerfile_debian
+++ b/.buildbot_dockerfile_debian
@@ -4,17 +4,16 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     --mount=target=/var/cache/apt,type=cache,sharing=locked \
   rm -f /etc/apt/apt.conf.d/docker-clean && \
   apt-get update && \
-  apt-get -y install clang-15 make curl cmake python3-distutils git \
-    ninja-build && \
-  update-alternatives --install /usr/bin/cc cc /usr/bin/clang-15 999 && \
-  update-alternatives --set cc /usr/bin/clang-15 && \
-  update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-15 999 && \
-  update-alternatives --set c++ /usr/bin/clang++-15 && \
-  ln -sf /usr/bin/clang-15 /usr/bin/clang && \
-  ln -sf /usr/bin/clang++-15 /usr/bin/clang++
+  apt-get -y install clang-17 make curl cmake git ninja-build && \
+  update-alternatives --install /usr/bin/cc cc /usr/bin/clang-17 999 && \
+  update-alternatives --set cc /usr/bin/clang-17 && \
+  update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-17 999 && \
+  update-alternatives --set c++ /usr/bin/clang++-17 && \
+  ln -sf /usr/bin/clang-17 /usr/bin/clang && \
+  ln -sf /usr/bin/clang++-17 /usr/bin/clang++
 ARG CI_UID
 RUN useradd -m -u ${CI_UID} ci && chown ${CI_UID}:${CI_UID} .
 ARG CI_RUNNER
 ENV CI_RUNNER=${CI_RUNNER}
 COPY --chown=${CI_UID}:${CI_UID} . .
-CMD sh -x .buildbot.sh
+CMD ["sh", "-x", ".buildbot.sh"]

--- a/llvm/include/llvm/Support/Yk.h
+++ b/llvm/include/llvm/Support/Yk.h
@@ -12,5 +12,6 @@ extern bool YkDontOptFuncABI;
 extern bool YkPatchCtrlPoint;
 extern bool YkPatchIdempotent;
 extern bool YkOutlineUntraceable;
+extern bool YkModuleClone;
 
 #endif

--- a/llvm/include/llvm/Transforms/Yk/ModuleClone.h
+++ b/llvm/include/llvm/Transforms/Yk/ModuleClone.h
@@ -1,7 +1,9 @@
 #ifndef LLVM_TRANSFORMS_YK_MODULE_CLONE_H
 #define LLVM_TRANSFORMS_YK_MODULE_CLONE_H
 
-#include "llvm/Pass.h"
+#include "llvm/IR/InstrTypes.h"
+#include "llvm/IR/PassManager.h"
+#include <map>
 
 // The prefix for optimised functions.
 #define YK_SWT_OPT_PREFIX "__yk_opt_"
@@ -10,7 +12,22 @@
 #define YK_SWT_OPT_MD YK_SWT_OPT_PREFIX
 
 namespace llvm {
-ModulePass *createYkModuleClonePass();
+
+class ModuleClonePass : public PassInfoMixin<ModuleClonePass> {
+public:
+  ModuleClonePass() {}
+  ModuleClonePass(ModuleClonePass &&Arg) = default;
+  PreservedAnalyses run(Module &, ModuleAnalysisManager &);
+
+  std::vector<Function *> getFunctionsWithIR(Module &);
+  bool shouldClone(Function &);
+  std::optional<std::map<Function *, Function *>>
+  cloneFunctionsInModule(Module &);
+  void removePromotion(CallBase *);
+  void removePromotionsAndDebugStrings(Function *);
+  void updateCalls(std::map<Function *, Function *> &);
+};
+
 } // namespace llvm
 
 #endif

--- a/llvm/lib/CodeGen/CodeGen.cpp
+++ b/llvm/lib/CodeGen/CodeGen.cpp
@@ -154,5 +154,4 @@ void llvm::initializeCodeGen(PassRegistry &Registry) {
   initializeYkSplitBlocksAfterCallsPass(Registry);
   initializeYkBasicBlockTracerPass(Registry);
   initializeYkShadowStackPass(Registry);
-  initializeYkModuleClonePass(Registry);
 }

--- a/llvm/lib/CodeGen/TargetPassConfig.cpp
+++ b/llvm/lib/CodeGen/TargetPassConfig.cpp
@@ -298,10 +298,6 @@ static cl::opt<bool>
     YkBasicBlockTracer("yk-basicblock-tracer", cl::init(false), cl::NotHidden,
                       cl::desc("Enables YK Software Tracer capability"));
 
-static cl::opt<bool>
-    YkModuleClone("yk-module-clone", cl::init(false), cl::NotHidden,
-                  cl::desc("Enables YK Module Cloning capability"));
-
 /// Allow standard passes to be disabled by command line options. This supports
 /// simple binary flags that either suppress the pass or do nothing.
 /// i.e. -disable-mypass=false has no effect.
@@ -1133,11 +1129,6 @@ bool TargetPassConfig::addCoreISelPasses() {
 }
 
 bool TargetPassConfig::addISelPasses() {
-  if (YkModuleClone) {
-    assert(YkBasicBlockTracer && "YkModuleClone requires YkShadowStackOpt");
-    addPass(createYkModuleClonePass());
-  }
-
   if (YkOutlineUntraceable) {
     addPass(createOutlineUntraceablePass());
   }

--- a/llvm/lib/Support/Yk.cpp
+++ b/llvm/lib/Support/Yk.cpp
@@ -149,6 +149,19 @@ struct CreateYkOutlineUntraceableParser {
 } // namespace
 static ManagedStatic<cl::opt<bool, true>, CreateYkOutlineUntraceableParser> YkOutlineUntraceableParser;
 
+bool YkModuleClone;
+namespace {
+struct CreateYkModuleCloneParser {
+  static void *call() {
+    return new cl::opt<bool, true>(
+        "yk-module-clone",
+        cl::desc("Enables YK Module Cloning capability"),
+        cl::NotHidden, cl::location(YkModuleClone));
+  }
+};
+} // namespace
+static ManagedStatic<cl::opt<bool, true>, CreateYkModuleCloneParser> YkModuleCloneParser;
+
 void llvm::initYkOptions() {
   *YkExtendedLLVMBBAddrMapSectionParser;
   *YkStackMapOffsetFixParser;
@@ -160,4 +173,5 @@ void llvm::initYkOptions() {
   *YkPatchCtrlPointParser;
   *YkPatchIdempotentParser;
   *YkOutlineUntraceableParser;
+  *YkModuleCloneParser;
 }

--- a/llvm/lib/Transforms/IPO/Inliner.cpp
+++ b/llvm/lib/Transforms/IPO/Inliner.cpp
@@ -59,6 +59,7 @@
 #include "llvm/Transforms/Utils/Cloning.h"
 #include "llvm/Transforms/Utils/Local.h"
 #include "llvm/Transforms/Utils/ModuleUtils.h"
+#include "llvm/Transforms/Yk/ModuleClone.h"
 #include <algorithm>
 #include <cassert>
 #include <functional>

--- a/llvm/lib/Transforms/Yk/ModuleClone.cpp
+++ b/llvm/lib/Transforms/Yk/ModuleClone.cpp
@@ -6,8 +6,8 @@
 // The cloned function (named with a `__yk_opt` prefix) is the optimised
 // version. The original version is the unoptimised version.
 //
-// Once an optimisd clone has been created, we then rewrite all calls inside to
-// call optimised versions of callees (where possible).
+// Once an optimised clone has been created, we then rewrite all calls inside
+// to call optimised versions of callees (where possible).
 //
 // Sometimes we are unable to clone a function. For example when a function has
 // its address taken. Cloning such a function would break "function pointer
@@ -16,15 +16,14 @@
 
 #include "llvm/Transforms/Yk/ModuleClone.h"
 #include "llvm/ADT/Twine.h"
+#include "llvm/Analysis/LoopInfo.h"
 #include "llvm/IR/BasicBlock.h"
 #include "llvm/IR/Function.h"
-#include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Instruction.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Verifier.h"
-#include "llvm/InitializePasses.h"
 #include "llvm/Linker/Linker.h"
 #include "llvm/Pass.h"
 #include "llvm/Transforms/Utils/Cloning.h"
@@ -35,189 +34,174 @@
 
 using namespace llvm;
 
-namespace llvm {
-void initializeYkModuleClonePass(PassRegistry &);
-} // namespace llvm
-
-namespace {
-struct YkModuleClone : public ModulePass {
-  static char ID;
-
-  YkModuleClone() : ModulePass(ID) {
-    initializeYkModuleClonePass(*PassRegistry::getPassRegistry());
-  }
-
-  // Find all functions that have IR.
-  std::vector<Function *> getFunctionsWithIR(Module &M) {
-    std::vector<Function *> Funcs;
-    for (llvm::Function &F : M) {
-      // Skip declarations. They have no IR, so there's nothing to clone.
-      if (F.isDeclaration()) {
-        continue;
-      }
-      Funcs.push_back(&F);
-    }
-    return Funcs;
-  }
-
-  // Decide if we should clone a function.
-  bool shouldClone(Function &F) {
-    assert(!F.isDeclaration());
-
+// Find all functions that have IR.
+std::vector<Function *> ModuleClonePass::getFunctionsWithIR(Module &M) {
+  std::vector<Function *> Funcs;
+  for (llvm::Function &F : M) {
+    // Skip declarations. They have no IR, so there's nothing to clone.
     if (F.isDeclaration()) {
-      return false;
+      continue;
     }
-    // If the address of a function is taken, then cloning it would break
-    // function pointer identity, which the program may rely on.
-    if (F.hasAddressTaken()) {
-      return false;
-    }
-    // For now we don't clone functions that contain a call to the control
-    // point.
-    if (containsControlPoint(F)) {
-      return false;
-    }
-    return true;
+    Funcs.push_back(&F);
   }
+  return Funcs;
+}
 
-  /// Clones all eligible functions within the given module.
-  ///
-  /// @param M The LLVM module containing the functions to be cloned.
-  ///
-  /// @return A map from the original function to the cloned function.
-  /// Functions which were no cloned will have a nullptr value in the map.
-  std::optional<std::map<Function *, Function *>>
-  cloneFunctionsInModule(Module &M) {
-    LLVMContext &Context = M.getContext();
-    std::vector Funcs = getFunctionsWithIR(M);
-    MDNode *OptMD = MDNode::get(Context, MDString::get(Context, ""));
+// Decide if we should clone a function.
+bool ModuleClonePass::shouldClone(Function &F) {
+  assert(!F.isDeclaration());
 
-    std::map<Function *, Function *> CloneMap;
-    for (Function *F : Funcs) {
-      auto OrigName = F->getName().str();
+  if (F.isDeclaration()) {
+    return false;
+  }
+  // If the address of a function is taken, then cloning it would break
+  // function pointer identity, which the program may rely on.
+  if (F.hasAddressTaken()) {
+    return false;
+  }
+  // For now we don't clone functions that contain a call to the control
+  // point.
+  if (containsControlPoint(F)) {
+    return false;
+  }
+  return true;
+}
 
-      // Maybe clone the function.
-      Function *ClonedOptFunc = nullptr;
-      if (shouldClone(*F)) {
-        ValueToValueMapTy VMap;
-        ClonedOptFunc = CloneFunction(F, VMap);
-        if (ClonedOptFunc == nullptr) {
-          Context.emitError("Failed to clone function: " + F->getName());
-          return std::nullopt;
-        }
-        // Copy arguments
-        auto DestArgIt = ClonedOptFunc->arg_begin();
-        for (const Argument &OrigArg : F->args()) {
-          DestArgIt->setName(OrigArg.getName());
-          VMap[&OrigArg] = &*DestArgIt++;
-        }
-        // Promotions and calls to yk_debug_str are not required for optimised
-        // clones and would only slow us down.
-        removePromotionsAndDebugStrings(ClonedOptFunc);
-        // The cloned function will be the optimised one.
-        Twine OptName = Twine(YK_SWT_OPT_PREFIX) + OrigName;
-        ClonedOptFunc->setName(OptName);
-        ClonedOptFunc->setMetadata(YK_SWT_OPT_MD, OptMD);
+/// Clones all eligible functions within the given module.
+///
+/// @param M The LLVM module containing the functions to be cloned.
+///
+/// @return A map from the original function to the cloned function.
+/// Functions which were no cloned will have a nullptr value in the map.
+std::optional<std::map<Function *, Function *>>
+ModuleClonePass::cloneFunctionsInModule(Module &M) {
+  LLVMContext &Context = M.getContext();
+  std::vector Funcs = getFunctionsWithIR(M);
+  MDNode *OptMD = MDNode::get(Context, MDString::get(Context, ""));
+
+  std::map<Function *, Function *> CloneMap;
+  for (Function *F : Funcs) {
+    auto OrigName = F->getName().str();
+
+    // Maybe clone the function.
+    Function *ClonedOptFunc = nullptr;
+    if (shouldClone(*F)) {
+      ValueToValueMapTy VMap;
+      ClonedOptFunc = CloneFunction(F, VMap);
+      if (ClonedOptFunc == nullptr) {
+        Context.emitError("Failed to clone function: " + F->getName());
+        return std::nullopt;
       }
-      // Update the map. If we didn't clone, then we insert a nullptr value.
-      CloneMap[F] = ClonedOptFunc;
+      // Copy arguments
+      auto DestArgIt = ClonedOptFunc->arg_begin();
+      for (const Argument &OrigArg : F->args()) {
+        DestArgIt->setName(OrigArg.getName());
+        VMap[&OrigArg] = &*DestArgIt++;
+      }
+      // Promotions and calls to yk_debug_str are not required for optimised
+      // clones and would only slow us down.
+      removePromotionsAndDebugStrings(ClonedOptFunc);
+      // The cloned function will be the optimised one.
+      Twine OptName = Twine(YK_SWT_OPT_PREFIX) + OrigName;
+      ClonedOptFunc->setName(OptName);
+      ClonedOptFunc->setMetadata(YK_SWT_OPT_MD, OptMD);
+
+      // Let subsequent inlining calls operate on optimised clones (but respect
+      // optnone)
+      if (!ClonedOptFunc->hasFnAttribute(Attribute::OptimizeNone)) {
+        ClonedOptFunc->removeFnAttr(Attribute::NoInline);
+      }
     }
-    return CloneMap;
+    // Update the map. If we didn't clone, then we insert a nullptr value.
+    CloneMap[F] = ClonedOptFunc;
   }
+  return CloneMap;
+}
 
-  void removePromotion(CallBase *CB) {
-    CallInst *CI = cast<CallInst>(CB);
-    assert(CI->arg_size() == 1);
-    Value *Arg = CI->getArgOperand(0);
-    assert(CI->getType() == Arg->getType());
-    CI->replaceAllUsesWith(Arg);
-    CI->eraseFromParent();
+void ModuleClonePass::removePromotion(CallBase *CB) {
+  CallInst *CI = cast<CallInst>(CB);
+  assert(CI->arg_size() == 1);
+  Value *Arg = CI->getArgOperand(0);
+  assert(CI->getType() == Arg->getType());
+  CI->replaceAllUsesWith(Arg);
+  CI->eraseFromParent();
+}
+
+void ModuleClonePass::removePromotionsAndDebugStrings(Function *F) {
+  // We have to do this in two phases to avoid iterator invalidation.
+  //
+  // 1. Find instructions to remove.
+  std::vector<CallInst *> Promotions;
+  std::vector<CallInst *> DebugStrs;
+  for (BasicBlock &BB : *F) {
+    for (Instruction &I : BB) {
+      if (CallBase *CB = dyn_cast<CallBase>(&I)) {
+        if (Function *CF = CB->getCalledFunction()) {
+          if (CF->getName().startswith(YK_PROMOTE_PREFIX)) {
+            Promotions.push_back(cast<CallInst>(CB));
+          } else if (CF->getName() == YK_DEBUG_STR) {
+            DebugStrs.push_back(cast<CallInst>(CB));
+          }
+        }
+      }
+    }
   }
+  // 2. Remove instructions.
+  for (CallInst *P : Promotions) {
+    removePromotion(P);
+  }
+  for (CallInst *D : DebugStrs) {
+    D->eraseFromParent();
+  }
+}
 
-  void removePromotionsAndDebugStrings(Function *F) {
-    // We have to do this in two phases to avoid iterator invalidation.
-    //
-    // 1. Find instructions to remove.
-    std::vector<CallInst *> Promotions;
-    std::vector<CallInst *> DebugStrs;
-    for (BasicBlock &BB : *F) {
+/// Updates direct calls in optimised clones so that they call optimised
+/// callees (if possible).
+///
+/// @param CloneMap Maps unoptimised function to their optimised counterparts
+/// (if they were cloned).
+void ModuleClonePass::updateCalls(std::map<Function *, Function *> &CloneMap) {
+
+  // Update calls in the optimised function.
+  for (auto [UnoptF, OptF] : CloneMap) {
+    if (OptF == nullptr) {
+      // We didn't clone that function. Skip.
+      continue;
+    }
+    // Loop over the optimised function, replacing callees with optimised
+    // versions where possible.
+    for (BasicBlock &BB : *OptF) {
       for (Instruction &I : BB) {
-        if (CallBase *CB = dyn_cast<CallBase>(&I)) {
-          if (Function *CF = CB->getCalledFunction()) {
-            if (CF->getName().startswith(YK_PROMOTE_PREFIX)) {
-              Promotions.push_back(cast<CallInst>(CB));
-            } else if (CF->getName() == YK_DEBUG_STR) {
-              DebugStrs.push_back(cast<CallInst>(CB));
-            }
-          }
-        }
-      }
-    }
-    // 2. Remove instructions.
-    for (CallInst *P : Promotions) {
-      removePromotion(P);
-    }
-    for (CallInst *D : DebugStrs) {
-      D->eraseFromParent();
-    }
-  }
-
-  /// Updates direct calls in optimised clones so that they call optimised
-  /// callees (if possible).
-  ///
-  /// @param CloneMap Maps unoptimised function to their optimised counterparts
-  /// (if they were cloned).
-  void updateCalls(std::map<Function *, Function *> &CloneMap) {
-
-    // Update calls in the optimised function.
-    for (auto [UnoptF, OptF] : CloneMap) {
-      if (OptF == nullptr) {
-        // We didn't clone that function. Skip.
-        continue;
-      }
-      // Loop over the optimised function, replacing callees with optimised
-      // versions where possible.
-      for (BasicBlock &BB : *OptF) {
-        for (Instruction &I : BB) {
-          if (auto *Call = dyn_cast<CallInst>(&I)) {
-            Function *CalledFunc = Call->getCalledFunction();
-            // We can only update only direct calls.
-            if (CalledFunc && !CalledFunc->isDeclaration() &&
-                !CalledFunc->isIntrinsic()) {
-              // Can we replace this call with a call to an optimised version?
-              // If OptCallee is nullptr then we didn't cloned the callee.
-              Function *OptCallee = CloneMap.at(CalledFunc);
-              if (OptCallee != nullptr) {
-                Call->setCalledFunction(OptCallee);
-              }
+        if (auto *Call = dyn_cast<CallInst>(&I)) {
+          Function *CalledFunc = Call->getCalledFunction();
+          // We can only update only direct calls.
+          if (CalledFunc && !CalledFunc->isDeclaration() &&
+              !CalledFunc->isIntrinsic()) {
+            // Can we replace this call with a call to an optimised version?
+            // If OptCallee is nullptr then we didn't cloned the callee.
+            Function *OptCallee = CloneMap.at(CalledFunc);
+            if (OptCallee != nullptr) {
+              Call->setCalledFunction(OptCallee);
             }
           }
         }
       }
     }
   }
+}
 
-  bool runOnModule(Module &M) override {
-    LLVMContext &Context = M.getContext();
-    auto CloneMap = cloneFunctionsInModule(M);
-    if (!CloneMap) {
-      Context.emitError("Failed to clone functions in module");
-      return false;
-    }
-    updateCalls(*CloneMap);
-
-    if (verifyModule(M, &errs())) {
-      Context.emitError("Module verification failed!");
-      return false;
-    }
-
-    return true;
+PreservedAnalyses ModuleClonePass::run(Module &M, ModuleAnalysisManager &MAM) {
+  LLVMContext &Context = M.getContext();
+  auto CloneMap = cloneFunctionsInModule(M);
+  if (!CloneMap) {
+    Context.emitError("Failed to clone functions in module");
+    return PreservedAnalyses::none();
   }
-};
-} // namespace
+  updateCalls(*CloneMap);
 
-char YkModuleClone::ID = 0;
+  if (verifyModule(M, &errs())) {
+    Context.emitError("Module verification failed!");
+  }
 
-INITIALIZE_PASS(YkModuleClone, DEBUG_TYPE, "yk module clone", false, false)
-
-ModulePass *llvm::createYkModuleClonePass() { return new YkModuleClone(); }
+  return PreservedAnalyses::none();
+}


### PR DESCRIPTION
This pass moves the position of the module cloner pass much earlier in the pipeline: immediately before the link-time inliner pass.

Optimised clones then have any `noinline` attribute removed, thus allowing them to be inlined into other optimised clones if necessary.

(Why are we talking about `noinline`? Currently early in the pipeline we mark functions containing loops noinline and yk_outline so that they don't end up getting traced, but this isn't required for optimised clones which will never be traced).

Note that the new position of the module clone pass means it would only take effect if the -O optimisation level is >= 2.

Gives about an 8% speedup on storage. According the earlier investigation this is a benchmark that still spends quite a lot of time in optimised clones.

The diff is large because the module clone pass had to be converted to a new-style pass, changing the indent of the whole file. There is one interesting addition hidden in all of that, which I will point out.