### PR TITLE
Ignore `noundef` ret attr in the serialiser

### DIFF
--- a/llvm/lib/YkIR/YkIRWriter.cpp
+++ b/llvm/lib/YkIR/YkIRWriter.cpp
@@ -876,7 +876,6 @@ private:
         return;
       }
     }
-    // We don't support ANY return value attributes yet.
     for (auto &Attr : Attrs.getRetAttrs()) {
       // The function returns or has UB. I *think* this can be safely ignored.
       if (Attr.getKindAsEnum() == Attribute::WillReturn) {
@@ -897,6 +896,9 @@ private:
         continue;
       }
       if (Attr.getKindAsEnum() == Attribute::Range) {
+        continue;
+      }
+      if (Attr.getKindAsEnum() == Attribute::NoUndef) {
         continue;
       }
       serialiseUnimplementedInstruction(

--- a/llvm/lib/YkIR/YkIRWriter.cpp
+++ b/llvm/lib/YkIR/YkIRWriter.cpp
@@ -1462,28 +1462,6 @@ private:
 
   void serialiseCastKind(enum CastKind Cast) { OutStreamer.emitInt8(Cast); }
 
-  /// Serialise a cast-like instruction.
-  void serialiseSExtInst(SExtInst *I, FuncLowerCtxt &FLCtxt, unsigned BBIdx,
-                         unsigned &InstIdx) {
-    // We don't support vectors.
-    if (I->getOperand(0)->getType()->isVectorTy()) {
-      serialiseUnimplementedInstruction(I, FLCtxt, BBIdx, InstIdx);
-      return;
-    }
-
-    // opcode:
-    serialiseOpcode(OpCodeCast);
-    // cast_kind:
-    serialiseCastKind(CastKindSignExt);
-    // val:
-    serialiseOperand(I, FLCtxt, I->getOperand(0));
-    // dest_type_idx:
-    OutStreamer.emitSizeT(typeIndex(I->getDestTy()));
-
-    FLCtxt.updateVLMap(I, {BBIdx, InstIdx});
-    InstIdx++;
-  }
-
   std::optional<CastKind> getCastKind(Instruction::CastOps Cast) {
     switch (Cast) {
     case Instruction::ZExt:


### PR DESCRIPTION
(and kill dead code)