### PR TITLE
Rename `yk_unroll_safe` to `yk_unroll`.

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -5291,10 +5291,10 @@ def YkIdempotent : InheritableAttr {
   let SimpleHandler = 1;
 }
 
-def YkUnrollSafe : InheritableAttr {
-  let Spellings = [GCC<"yk_unroll_safe">, Declspec<"yk_unroll_safe">];
+def YkUnroll : InheritableAttr {
+  let Spellings = [GCC<"yk_unroll">, Declspec<"yk_unroll">];
   let Subjects = SubjectList<[Function]>;
-  let Documentation = [YkUnrollSafeDocs];
+  let Documentation = [YkUnrollDocs];
   let SimpleHandler = 1;
 }
 

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -9068,10 +9068,10 @@ def YkIdempotentDocs : Documentation {
   let Content = [{tells the yk trace optimiser that this function is idempotent}];
 }
 
-def YkUnrollSafeDocs : Documentation {
+def YkUnrollDocs : Documentation {
   let Category = DocCatFunction;
   let Content = [{
-  The ``yk_unroll_safe`` attribute tells the Yk JIT that during tracing, calls
+  The ``yk_unroll`` attribute tells the Yk JIT that during tracing, calls
   to the annotated function can be inlined, even if it contains loops. By
   default only calls to functions that contain no loops are inlined.
   }];

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -2964,7 +2964,7 @@ void CodeGenModule::SetLLVMFunctionAttributesForDefinition(const Decl *D,
   }
 
   // Mark all functions containing loops with `yk_outline` unless the function
-  // was annotated `yk_unroll_safe`.
+  // was annotated `yk_unroll`.
   //
   // This needs to be gated so that we don't impact the normal clang and LLVM
   // tests.
@@ -2974,13 +2974,13 @@ void CodeGenModule::SetLLVMFunctionAttributesForDefinition(const Decl *D,
   // function anyway, so there's no need to conservatively add `yk_outline`.
   //
   // FIXME: This doesn't really belong in clang. It should be put into an
-  // early-running LLVM pass (and we would have to pass down the yk_unroll_safe
+  // early-running LLVM pass (and we would have to pass down the yk_unroll
   // atrributes to the IR-level). Then this logic would be frontend agnostic.
   if (CodeGenOpts.YkNoinlineFuncsWithLoops && !F->empty()) {
     llvm::DominatorTree DT(*F);
     llvm::LoopInfo LI(DT);
     if (!LI.empty()) {
-      if (!D->hasAttr<YkUnrollSafeAttr>())
+      if (!D->hasAttr<YkUnrollAttr>())
         B.addAttribute(YK_OUTLINE_FNATTR);
 
       // Note that we still mark the loopy function `F` with `noinline` (to
@@ -2989,7 +2989,7 @@ void CodeGenModule::SetLLVMFunctionAttributesForDefinition(const Decl *D,
       //
       // * if `F` is to be inlined into a trace and we don't block AOT inlining
       // then `F` may get AOT inlined into a parent function which contains
-      // loops but isn't marked `yk_unroll_safe`. The trace would have to call
+      // loops but isn't marked `yk_unroll`. The trace would have to call
       // the parent, meaning that `F` would not be inlined into the trace!
       //
       // * if `F` is to be outlined in a trace and we don't block AOT inlining,

--- a/clang/test/Misc/pragma-attribute-supported-attributes-list.test
+++ b/clang/test/Misc/pragma-attribute-supported-attributes-list.test
@@ -242,6 +242,6 @@
 // CHECK-NEXT: YkIdempotent (SubjectMatchRule_function)
 // CHECK-NEXT: YkIndirectInline (SubjectMatchRule_function)
 // CHECK-NEXT: YkOutline (SubjectMatchRule_function)
-// CHECK-NEXT: YkUnrollSafe (SubjectMatchRule_function)
+// CHECK-NEXT: YkUnroll (SubjectMatchRule_function)
 // CHECK-NEXT: ZeroCallUsedRegs (SubjectMatchRule_function)
 // CHECK-NEXT: End of supported attributes.


### PR DESCRIPTION
This better matches `yk_outline` etc.