### PR TITLE
Skip noalias intrinsic

### DIFF
--- a/llvm/lib/YkIR/YkIRWriter.cpp
+++ b/llvm/lib/YkIR/YkIRWriter.cpp
@@ -1002,6 +1002,12 @@ private:
     if (I->getIntrinsicID() == Intrinsic::experimental_stackmap) {
       return;
     }
+    // @llvm.experimental.noalias.scope.decl is an optimisation hint emitted for
+    // functions. It carries a MetadataAsValue operand that the serialiser cannot handle. 
+    // The intrinsic has no effect on program semantics, so skip it for now.
+    if (I->getIntrinsicID() == Intrinsic::experimental_noalias_scope_decl) {
+      return;
+    }
 
     // Calls to functions that promote runtime values are given their own
     // bytecodes so that they can more be easily identified.


### PR DESCRIPTION
Skip serialisation of @llvm.experimental.noalias.scope.decl intrinsic.
https://llvm.org/docs/LangRef.html#noalias-and-alias-scope-metadata

@llvm.experimental.noalias.scope.decl is an optimisation hint emitted
for CSOM functions. It carries a MetadataAsValue operand that the
serialiser cannot handle. The intrinsic has no effect on program
semantics, so skip it for now.