### PR TITLE
Skip cloning functions with available_externally linkage.

### DIFF
--- a/llvm/lib/Transforms/Yk/ModuleClone.cpp
+++ b/llvm/lib/Transforms/Yk/ModuleClone.cpp
@@ -56,6 +56,14 @@ bool ModuleClonePass::shouldClone(Function &F) {
   if (F.isDeclaration()) {
     return false;
   }
+  // Functions with available_externally linkage have bodies present only as
+  // optimisation hints; the linker treats them as external and will never emit
+  // a definition for them. Cloning such a function would produce an
+  // __yk_opt__ copy whose definition is also silently dropped, leaving call
+  // sites that reference an undefined symbol.
+  if (F.hasAvailableExternallyLinkage()) {
+    return false;
+  }
   // If the address of a function is taken, then cloning it would break
   // function pointer identity, which the program may rely on.
   if (F.hasAddressTaken()) {

--- a/llvm/lib/YkIR/YkIRWriter.cpp
+++ b/llvm/lib/YkIR/YkIRWriter.cpp
@@ -1471,6 +1471,7 @@ private:
     // elem:
     serialiseOperand(I, FLCtxt, I->getInsertedValueOperand());
 
+    FLCtxt.updateVLMap(I, {BBIdx, InstIdx});
     InstIdx++;
   }
 


### PR DESCRIPTION
Some STL functions (e.g. std::string::operator=, std::stringstream::stringstream) appear in the module with  `available_externally` linkage - their bodies are included in bitcode only as inlining hints; the linker will never
emits a definition for them. shouldClone only checked isDeclaration(), which returns false for available_externally   
functions since they do have bodies.                      

So YkModuleClone created __yk_opt__ clones of these STL functions, rewrote calls inside opt clones to call those copies -and then the linker silently dropped the __yk_opt__ definitions.