### PR TITLE
Change how `yk_promote` stackmaps are generated.

### DIFF
--- a/llvm/lib/Transforms/Yk/StackMaps.cpp
+++ b/llvm/lib/Transforms/Yk/StackMaps.cpp
@@ -91,12 +91,6 @@ public:
                 continue;
               }
             }
-            // OPT: Geting the live vars from before `I` might include
-            // variables that die immediately after the call. We should try
-            // using the live variables *after* the call, but making sure not to
-            // include the value computed by `I` itself (since that doesn't
-            // exist at the time of the call).
-            SMCalls.push_back({&I, LA.getLiveVarsBefore(&I)});
             if (CF && CF->getName().starts_with("__yk_promote")) {
               // If it's a call to yk_promote* then the return value of the
               // promotion needs to be tracked too. This is because the trace
@@ -104,7 +98,9 @@ public:
               // replace them with a guard that deopts to immediately after the
               // call (at which point the return value is live and needs to be
               // materialised for correctness).
-              SMCalls.back().second.push_back(&CI);
+              SMCalls.push_back({&I, LA.getLiveVarsBefore(I.getNextNode())});
+            } else {
+              SMCalls.push_back({&I, LA.getLiveVarsBefore(&I)});
             }
           } else if ((isa<BranchInst>(I) &&
                       cast<BranchInst>(I).isConditional()) ||


### PR DESCRIPTION
`yk_promote` is treated differently to normal calls: we only care about the values _after_ the function being called (not before/on the call).

Previously we calculated the live variables before a `yk_promote` call, then manually placed its return variable into those live variables. This commit simply calculates the live variables at the instruction immediately after a `yk_promote` call. This means that we force parameters to live longer than they might need to. In practise there's probably not much difference (variables passed to `yk_promote` tend to be long lived), but this version is easier to understand.

While I'm here remove a misleading `OPT` comment for the more general case: since we can deopt in the "middle of" a call, we need to calculate the live variables at the point of the call, not after.