### PR TITLE
Remove outdated code.

### DIFF
--- a/llvm/include/llvm/CodeGen/AsmPrinter.h
+++ b/llvm/include/llvm/CodeGen/AsmPrinter.h
@@ -365,12 +365,6 @@ public:
   /// definition in the same module.
   MCSymbol *getSymbolPreferLocal(const GlobalValue &GV) const;
 
-  /// Maps call instructions to the label emitted just after the call. The label
-  /// is later used to calculate the correct offset of the call instruction
-  /// without interference from caller-saved registers which are sometimes
-  /// emitted inbetween call and stackmap.
-  MCSymbol *YkLastCallLabel = nullptr;
-
   bool doesDwarfUseRelocationsAcrossSections() const {
     return DwarfUsesRelocationsAcrossSections;
   }

--- a/llvm/lib/Target/X86/X86MCInstLower.cpp
+++ b/llvm/lib/Target/X86/X86MCInstLower.cpp
@@ -1024,25 +1024,9 @@ void X86AsmPrinter::LowerPATCHABLE_OP(const MachineInstr &MI,
 void X86AsmPrinter::LowerSTACKMAP(const MachineInstr &MI) {
   SMShadowTracker.emitShadowPadding(*OutStreamer, getSubtargetInfo());
 
-  // When the stackmap is attached to a function call, caller-saved register
-  // loads may be emitted in-between call and stackmap call, thus skewing the
-  // reported offset.
-  // This makes it impossible to reliably continue at the correct location after
-  // deoptimisation has occured. In order to fix this, we insert labels after
-  // every call that could lead to a guard failure, and store the last such
-  // label inside `YkLastCallLabel`. If `YkLastCallLabel` is set (i.e. the
-  // stackmap was inserted after a call) use it to calculate the stackmap
-  // offset, otherwise (i.e. the stackmap was inserted before a branch) generate
-  // a new label as per ususual.
-  MCSymbol *MILabel;
-  if (YkLastCallLabel != nullptr) {
-    MILabel = YkLastCallLabel;
-    YkLastCallLabel = nullptr;
-  } else {
-    auto &Ctx = OutStreamer->getContext();
-    MILabel = Ctx.createTempSymbol();
-    OutStreamer->emitLabel(MILabel);
-  }
+  auto &Ctx = OutStreamer->getContext();
+  MCSymbol *MILabel = Ctx.createTempSymbol();
+  OutStreamer->emitLabel(MILabel);
   SM.recordStackMap(*MILabel, MI, StackmapSpillMaps[&MI]);
   unsigned NumShadowBytes = MI.getOperand(1).getImm();
   SMShadowTracker.reset(NumShadowBytes);


### PR DESCRIPTION
`YkLastCallPtr` is never set to non-null, so none of this code does anything. I suspect it predates the "fix stackmaps" pass and wasn't noticed as a candidate for removal after that was merged.