### PR TITLE
Don't move stackmaps that aren't associated with normal functions.

### DIFF
--- a/llvm/lib/CodeGen/Yk/FixStackmapsSpillReloads.cpp
+++ b/llvm/lib/CodeGen/Yk/FixStackmapsSpillReloads.cpp
@@ -158,6 +158,8 @@
 #include "llvm/CodeGen/StackMaps.h"
 #include "llvm/CodeGen/TargetInstrInfo.h"
 #include "llvm/IR/DebugLoc.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/GlobalAlias.h"
 #include "llvm/InitializePasses.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Transforms/Yk/BasicBlockTracer.h"
@@ -212,18 +214,24 @@ bool FixStackmapsSpillReloads::runOnMachineFunction(MachineFunction &MF) {
     std::map<Register, MachineInstr *> Spills;
     for (MachineInstr &MI : MBB) {
       if (MI.isCall() && !MI.isInlineAsm()) {
-        // YKFIXME: Do we need to check for intrinsics here or have they been
-        // removed during lowering?
         if (MI.getOpcode() != TargetOpcode::STACKMAP &&
             MI.getOpcode() != TargetOpcode::PATCHPOINT) {
           MachineOperand Op = MI.getOperand(0);
-          if (Op.isGlobal() &&
-              (Op.getGlobal()->getName() == YK_TRACE_FUNCTION)) {
-            // Op.getGlobal()->getGlobalIdentifier() == YK_TRACE_FUNCTION) {
-            // `YK_TRACE_FUNCTION` calls don't require stackmaps so we don't
-            // need to adjust anything here. In fact, doing so will skew any
-            // stackmap that follows.
-            continue;
+          if (Op.isGlobal()) {
+            const GlobalValue *GV = MI.getOperand(0).getGlobal();
+            if (GV->getName() == YK_TRACE_FUNCTION) {
+              // `YK_TRACE_FUNCTION` calls don't require stackmaps.
+              continue;
+            }
+            const Function *F;
+            if (const auto *GA = dyn_cast<GlobalAlias>(GV))
+              F = dyn_cast<Function>(GA->getAliaseeObject());
+            else
+              F = dyn_cast<Function>(GV);
+            if (F->isIntrinsic() || F->isDeclaration() ||
+                F->getName().starts_with("__yk_promote")) {
+              continue;
+            }
           }
           // If we see a normal function call we know it will be followed by a
           // STACKMAP instruction. Set `Collect` to `true` to collect all spill

--- a/llvm/test/CodeGen/X86/yk-stackmaps-external-call-branch-fix.ll
+++ b/llvm/test/CodeGen/X86/yk-stackmaps-external-call-branch-fix.ll
@@ -1,0 +1,54 @@
+; RUN: llc -stop-after fix-stackmaps-spill-reloads --yk-insert-stackmaps --yk-stackmap-spillreloads-fix -mtriple=x86_64-- < %s | FileCheck %s
+
+; Direct calls to external declarations do not get call stackmaps. If a branch
+; stackmap follows such a call, the spill/reload fixer must not move that branch
+; stackmap back to the external call.
+
+declare i32 @external(i32)
+
+define i32 @external_then_branch(i32 %x, i32 %y) #0 {
+; CHECK-LABEL: name: external_then_branch
+; CHECK:       CALL64pcrel32 target-flags(x86-plt) @external
+; CHECK:       CMP32rr
+; CHECK:       renamable $cl = SETCCr
+; CHECK:       STACKMAP {{.*}} $cl, 3
+; CHECK:       CMP32rr
+; CHECK:       JCC_1
+entry:
+  %e = call i32 @external(i32 %x)
+  %cmp = icmp sgt i32 %e, %y
+  br i1 %cmp, label %then, label %else
+
+then:
+  %t = add i32 %e, %x
+  ret i32 %t
+
+else:
+  %f = sub i32 %y, %x
+  ret i32 %f
+}
+
+define i32 @indirect_then_branch(ptr %fp, i32 %x, i32 %y) #0 {
+; CHECK-LABEL: name: indirect_then_branch
+; CHECK:       CALL64r
+; CHECK:       STACKMAP
+; CHECK:       CMP32rr
+; CHECK:       renamable $cl = SETCCr
+; CHECK:       STACKMAP {{.*}} $cl, 3
+; CHECK:       CMP32rr
+; CHECK:       JCC_1
+entry:
+  %i = call i32 %fp(i32 %x)
+  %cmp = icmp sgt i32 %i, %y
+  br i1 %cmp, label %then, label %else
+
+then:
+  %t = add i32 %i, %x
+  ret i32 %t
+
+else:
+  %f = sub i32 %y, %x
+  ret i32 %f
+}
+
+attributes #0 = { noinline nounwind "frame-pointer"="all" }

--- a/llvm/test/CodeGen/X86/yk-stackmaps-spillreloads-fix.ll
+++ b/llvm/test/CodeGen/X86/yk-stackmaps-spillreloads-fix.ll
@@ -2,7 +2,7 @@
 
 ; CHECK-LABEL: name:            main
 ; CHECK-LABEL: bb.0 (%ir-block.1):
-; CHECK-LABEL: CALL64pcrel32 target-flags(x86-plt) @foo2,
+; CHECK-LABEL: CALL64pcrel32 @foo2,
 ; CHECK-NEXT: STACKMAP 1, 0, renamable $ebx, 3, renamable $r14d, 3, 1, 4, $rbp, -48, 3, renamable $r12d, 3, 1, 4, $rbp, -52, 3, renamable $r15d, 3, renamable $r13d, 3, implicit-def dead early-clobber $r11
 
 @.str = private unnamed_addr constant [13 x i8] c"%d %d %d %d\0A\00", align 1
@@ -75,7 +75,10 @@ define dso_local i32 @main(i32 noundef %0) #0 {
   ret i32 0
 }
 
-declare void @foo2(...)
+define dso_local i32 @foo2(...) #0 {
+  ret i32 0
+}
+
 declare void @llvm.experimental.stackmap(i64, i32, ...)
 
 attributes #0 = { noinline nounwind optnone uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }


### PR DESCRIPTION
The new test previously failed. Note we have to update a previous test since `foo2`, lacking a body, is considered by the new fix to just be a declaration.