### PR TITLE
Sort live variables in use-def order.

### DIFF
--- a/llvm/include/llvm/Transforms/Yk/LivenessAnalysis.h
+++ b/llvm/include/llvm/Transforms/Yk/LivenessAnalysis.h
@@ -1,7 +1,6 @@
 #ifndef __YK_LIVENESS_H
 #define __YK_LIVENESS_H
 
-#include "llvm/IR/Dominators.h"
 #include "llvm/IR/Instructions.h"
 
 #include <map>
@@ -22,9 +21,6 @@ class LivenessAnalysis {
 
   /// Find the successor instructions of the specified instruction.
   std::set<Instruction *> getSuccessorInstructions(Instruction *I);
-
-  // A domniator tree used to sort the live variables.
-  DominatorTree DT;
 
   /// Replaces the set `S` with the set `R`, returning if the set changed.
   bool updateValueSet(std::set<Value *> &S, const std::set<Value *> &R);

--- a/llvm/lib/Transforms/Yk/LivenessAnalysis.cpp
+++ b/llvm/lib/Transforms/Yk/LivenessAnalysis.cpp
@@ -10,7 +10,6 @@
 #include "llvm/Transforms/Yk/LivenessAnalysis.h"
 #include "llvm/ADT/PostOrderIterator.h"
 #include "llvm/IR/BasicBlock.h"
-#include "llvm/IR/Dominators.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Instructions.h"
@@ -69,9 +68,6 @@ LivenessAnalysis::LivenessAnalysis(Function *Func) {
   // Compute defs and uses for each instruction.
   std::map<Instruction *, std::set<Value *>> Defs;
   std::map<Instruction *, std::set<Value *>> Uses;
-
-  // Create a domniator tree so we can later sort the live variables.
-  DT = DominatorTree(*Func);
 
   for (BasicBlock &BB : *Func) {
     for (Instruction &I : BB) {
@@ -199,17 +195,61 @@ LivenessAnalysis::LivenessAnalysis(Function *Func) {
 }
 
 std::vector<Value *> LivenessAnalysis::getLiveVarsBefore(Instruction *I) {
-  std::set<Value *> Res = In[I];
-  // Sort the live variables by order of appearance using a dominator tree. The
-  // order is important for frame construction during deoptimisation: since live
-  // variables may reference other live variables they need to be proceesed in
-  // the order they appear in the module.
-  std::vector<Value *> Sorted(Res.begin(), Res.end());
-  std::sort(Sorted.begin(), Sorted.end(), [this](Value *A, Value *B) {
-    if (isa<Instruction>(B))
-      return DT.dominates(A, cast<Instruction>(B));
-    return false;
-  });
+  const std::set<Value *> &Live = In[I];
+  Function *Func = I->getFunction();
+
+  std::vector<Value *> Sorted; // The always-use-def-sorted list we return.
+  // Arguments are always in def-use order by definition, so can go straight
+  // into `Sorted`.
+  for (Argument &Arg : Func->args())
+    if (Live.count(&Arg) > 0)
+      Sorted.push_back(&Arg);
+
+  // We need a work queue for the results produced by `Instruction`s. Because,
+  // in general, we expect there to be relatively few elements, we use a
+  // `Vector`, even though in the later loop we'll be regularly popping
+  // elements from towards the front (so we will shuffle elements around in
+  // memory more than we'd like).
+  std::vector<Instruction *> Work;
+  // First, push every live value/`Instruction` into Work.
+  for (BasicBlock &BB : *Func)
+    for (Instruction &Inst : BB)
+      if (Live.count(&Inst) > 0)
+        Work.push_back(&Inst);
+
+  // Second, iterate over the queue performing a partial topological sort.
+  //
+  // On each iteration, find elements that do not use results produced by other
+  // elements in the queue, and push them into `Sorted`. This reaches a fixed
+  // point in two ways: we've emptied the queue entirely; or the only remaining
+  // elements form a cycle and have to be pushed into `Sorted` as-is.
+  while (!Work.empty()) {
+    bool Changed = false;
+    for (auto It = Work.begin(); It != Work.end();) {
+      bool isUsed = false; // Is this Instruction used elsewhere in the queue?
+      for (Value *Op : (*It)->operands()) {
+        if (std::find(Work.begin(), Work.end(), Op) != Work.end()) {
+          isUsed = true;
+          break;
+        }
+      }
+      if (isUsed) {
+        It++;
+        continue;
+      }
+      Sorted.push_back(*It);
+      It = Work.erase(It);
+      Changed = true;
+    }
+    if (!Changed) {
+      // If we get to this point, the remaining elements in the queue form a
+      // cycle: we thus append them to `Sorted` in the order we encountered
+      // them when iterating over the basic instructions in the basic block(s)
+      // they came from.
+      Sorted.insert(Sorted.end(), Work.begin(), Work.end());
+      break;
+    }
+  }
   return Sorted;
 }
 

--- a/llvm/test/CodeGen/X86/yk-stackmaps-liveness-dependency-order.ll
+++ b/llvm/test/CodeGen/X86/yk-stackmaps-liveness-dependency-order.ll
@@ -1,0 +1,82 @@
+; RUN: llc -stop-after=yk-stackmaps --yk-insert-stackmaps < %s | FileCheck %s
+
+define i32 @callee(i32 %x) {
+entry:
+  ret i32 %x
+}
+
+define i32 @order(i32 %x) {
+; CHECK-LABEL: define i32 @order
+; CHECK: %r = call i32 @callee(i32 %x)
+; CHECK-NEXT: call void (i64, i32, ...) @llvm.experimental.stackmap(i64 1, i32 0, i32 %x, i32 %local, i32 %from_later_block)
+entry:
+  br label %later
+
+join:
+  %local = add i32 %x, 7
+  %r = call i32 @callee(i32 %x)
+  %use1 = add i32 %local, %from_later_block
+  %use2 = add i32 %use1, %r
+  ret i32 %use2
+
+later:
+  %from_later_block = add i32 %x, 1
+  br label %join
+}
+
+define i32 @dependency_order(i32 %x) {
+; CHECK-LABEL: define i32 @dependency_order
+; CHECK: %r = call i32 @callee(i32 %x)
+; CHECK-NEXT: call void (i64, i32, ...) @llvm.experimental.stackmap(i64 2, i32 0, i32 %x, i32 %base, i32 %mid, i32 %derived)
+entry:
+  br label %def
+
+use:
+  %mid = add i32 %base, 1
+  %derived = add i32 %mid, 1
+  %r = call i32 @callee(i32 %x)
+  %keep1 = add i32 %derived, %mid
+  %keep2 = add i32 %keep1, %base
+  %keep3 = add i32 %keep2, %r
+  ret i32 %keep3
+
+def:
+  %base = add i32 %x, 1
+  br label %use
+}
+
+define i32 @phi_incoming(i1 %cond, i32 %x) {
+; CHECK-LABEL: define i32 @phi_incoming
+; CHECK: %incoming = add i32 %x, 1
+; CHECK-NEXT: call void (i64, i32, ...) @llvm.experimental.stackmap(i64 3, i32 0, i1 %cond, i32 %x, i32 %incoming)
+; CHECK-NEXT: br i1 %cond, label %join, label %exit
+entry:
+  %incoming = add i32 %x, 1
+  br i1 %cond, label %join, label %exit
+
+join:
+  %p = phi i32 [ %incoming, %entry ]
+  ret i32 %p
+
+exit:
+  ret i32 %x
+}
+
+define i32 @phi_cycle(i1 %cond, i32 %x) {
+; CHECK-LABEL: define i32 @phi_cycle
+; CHECK: %r = call i32 @callee(i32 %x)
+; CHECK-NEXT: call void (i64, i32, ...) @llvm.experimental.stackmap(i64 4, i32 0, i1 %cond, i32 %x, i32 %a, i32 %b)
+entry:
+  br label %loop
+
+loop:
+  %a = phi i32 [ %x, %entry ], [ %b, %loop ]
+  %b = phi i32 [ 0, %entry ], [ %a, %loop ]
+  %r = call i32 @callee(i32 %x)
+  %keep1 = add i32 %a, %b
+  %keep2 = add i32 %keep1, %r
+  br i1 %cond, label %loop, label %exit
+
+exit:
+  ret i32 %keep2
+}


### PR DESCRIPTION
Before this PR, `getLiveVarsBefore` sorted variables in dominator order, but that is not quite the same as use-def order. [It's also unclear to me if the lambda passed to `sort` is safe as a sorting condition.] This PR sorts variables in use-def order (e.g. the new `@order` test produces a different ordering). It is a little slower, but not to the point I can really notice in practice on yklua.