### PR TITLE
Record return values in call stackmaps.

### DIFF
--- a/llvm/lib/Transforms/Yk/StackMaps.cpp
+++ b/llvm/lib/Transforms/Yk/StackMaps.cpp
@@ -105,7 +105,26 @@ public:
               SMCalls.push_back(
                   {I.getNextNode(), LA.getLiveVarsBefore(I.getNextNode())});
             } else {
+              // YKFIXME: As a horrible hack to make stackmaps more like
+              // patchpoints, we add a final element to function call stackmaps
+              // that captures that call's return value if (a) the function can
+              // return a value (b) that value is used after this call. If
+              // either of those two things is not true, we duplicate the last
+              // existing value of the stackmap (if such a value exists). This
+              // behaviour is relied on by yk's aot_ir to create two statepoints
+              // from this single stackmap.
               SMCalls.push_back({I.getNextNode(), LA.getLiveVarsBefore(&I)});
+              bool ReturnIsLive = false;
+              if (!CI.getType()->isVoidTy()) {
+                auto Next = LA.getLiveVarsBefore(I.getNextNode());
+                ReturnIsLive =
+                    std::find(Next.begin(), Next.end(), &CI) != Next.end();
+              }
+              if (ReturnIsLive)
+                SMCalls.back().live_vars.push_back(&CI);
+              else if (!SMCalls.back().live_vars.empty())
+                SMCalls.back().live_vars.push_back(
+                    SMCalls.back().live_vars.back());
             }
           } else if ((isa<BranchInst>(I) &&
                       cast<BranchInst>(I).isConditional()) ||

--- a/llvm/lib/YkIR/YkIRWriter.cpp
+++ b/llvm/lib/YkIR/YkIRWriter.cpp
@@ -730,6 +730,7 @@ private:
     OutStreamer.emitInt64(SMId);
 
     int Skip = 0;
+    bool DupLast = false;
     if (I->getIntrinsicID() == Intrinsic::experimental_stackmap) {
       // Skip the following arguments: ID, shadow.
       Skip = 2;
@@ -737,15 +738,19 @@ private:
       // Skip the following arguments: ID, shadow, target, target arguments.
       Skip = 4 + cast<ConstantInt>(I->getOperand(PPArgIdxNumTargetArgs))
                      ->getZExtValue();
+      DupLast = I->arg_size() > static_cast<unsigned>(Skip);
     }
 
     // num_lives:
-    OutStreamer.emitInt32(I->arg_size() - Skip);
+    OutStreamer.emitInt32(I->arg_size() - Skip + (DupLast ? 1 : 0));
 
     // lives:
     for (unsigned OI = Skip; OI < I->arg_size(); OI++) {
       serialiseOperand(I, FLCtxt, I->getOperand(OI));
     }
+
+    if (DupLast)
+      serialiseOperand(I, FLCtxt, I->getOperand(I->arg_size() - 1));
   }
 
   void serialisePromotion(CallInst *I, FuncLowerCtxt &FLCtxt,

--- a/llvm/test/CodeGen/X86/yk-stackmaps-call-return-values.ll
+++ b/llvm/test/CodeGen/X86/yk-stackmaps-call-return-values.ll
@@ -1,0 +1,70 @@
+; RUN: llc -stop-after=yk-stackmaps --yk-insert-stackmaps < %s | FileCheck %s
+
+define i32 @callee(i32 %x) {
+entry:
+  %r = add i32 %x, 1
+  ret i32 %r
+}
+
+define void @void_callee(i32 %x) {
+entry:
+  ret void
+}
+
+define i32 @zero() {
+entry:
+  ret i32 0
+}
+
+define i32 @direct_used_return(i32 %x) {
+; CHECK-LABEL: define i32 @direct_used_return
+; CHECK: %r = call i32 @callee(i32 %x)
+; CHECK-NEXT: call void (i64, i32, ...) @llvm.experimental.stackmap(i64 {{[0-9]+}}, i32 0, i32 %x, i32 %keep, i32 %r)
+entry:
+  %keep = add i32 %x, 7
+  %r = call i32 @callee(i32 %x)
+  %use = add i32 %r, %keep
+  ret i32 %use
+}
+
+define i32 @only_used_return() {
+; CHECK-LABEL: define i32 @only_used_return
+; CHECK: %r = call i32 @zero()
+; CHECK-NEXT: call void (i64, i32, ...) @llvm.experimental.stackmap(i64 {{[0-9]+}}, i32 0, i32 %r)
+entry:
+  %r = call i32 @zero()
+  ret i32 %r
+}
+
+define i32 @direct_unused_return(i32 %x) {
+; CHECK-LABEL: define i32 @direct_unused_return
+; CHECK: %r = call i32 @callee(i32 %x)
+; CHECK-NEXT: call void (i64, i32, ...) @llvm.experimental.stackmap(i64 {{[0-9]+}}, i32 0, i32 %x, i32 %keep, i32 %keep)
+entry:
+  %keep = add i32 %x, 7
+  %r = call i32 @callee(i32 %x)
+  %use = add i32 %keep, 1
+  ret i32 %use
+}
+
+define i32 @void_call(i32 %x) {
+; CHECK-LABEL: define i32 @void_call
+; CHECK: call void @void_callee(i32 %x)
+; CHECK-NEXT: call void (i64, i32, ...) @llvm.experimental.stackmap(i64 {{[0-9]+}}, i32 0, i32 %x, i32 %keep, i32 %keep)
+entry:
+  %keep = add i32 %x, 7
+  call void @void_callee(i32 %x)
+  %use = add i32 %keep, 1
+  ret i32 %use
+}
+
+define i32 @indirect_used_return(ptr %fp, i32 %x) {
+; CHECK-LABEL: define i32 @indirect_used_return
+; CHECK: %r = call i32 %fp(i32 %x)
+; CHECK-NEXT: call void (i64, i32, ...) @llvm.experimental.stackmap(i64 {{[0-9]+}}, i32 0, ptr %fp, i32 %x, i32 %keep, i32 %r)
+entry:
+  %keep = add i32 %x, 7
+  %r = call i32 %fp(i32 %x)
+  %use = add i32 %r, %keep
+  ret i32 %use
+}

--- a/llvm/test/CodeGen/X86/yk-stackmaps-liveness-dependency-order.ll
+++ b/llvm/test/CodeGen/X86/yk-stackmaps-liveness-dependency-order.ll
@@ -8,7 +8,7 @@ entry:
 define i32 @order(i32 %x) {
 ; CHECK-LABEL: define i32 @order
 ; CHECK: %r = call i32 @callee(i32 %x)
-; CHECK-NEXT: call void (i64, i32, ...) @llvm.experimental.stackmap(i64 1, i32 0, i32 %x, i32 %local, i32 %from_later_block)
+; CHECK-NEXT: call void (i64, i32, ...) @llvm.experimental.stackmap(i64 1, i32 0, i32 %x, i32 %local, i32 %from_later_block, i32 %r)
 entry:
   br label %later
 
@@ -27,7 +27,7 @@ later:
 define i32 @dependency_order(i32 %x) {
 ; CHECK-LABEL: define i32 @dependency_order
 ; CHECK: %r = call i32 @callee(i32 %x)
-; CHECK-NEXT: call void (i64, i32, ...) @llvm.experimental.stackmap(i64 2, i32 0, i32 %x, i32 %base, i32 %mid, i32 %derived)
+; CHECK-NEXT: call void (i64, i32, ...) @llvm.experimental.stackmap(i64 2, i32 0, i32 %x, i32 %base, i32 %mid, i32 %derived, i32 %r)
 entry:
   br label %def
 
@@ -65,7 +65,7 @@ exit:
 define i32 @phi_cycle(i1 %cond, i32 %x) {
 ; CHECK-LABEL: define i32 @phi_cycle
 ; CHECK: %r = call i32 @callee(i32 %x)
-; CHECK-NEXT: call void (i64, i32, ...) @llvm.experimental.stackmap(i64 4, i32 0, i1 %cond, i32 %x, i32 %a, i32 %b)
+; CHECK-NEXT: call void (i64, i32, ...) @llvm.experimental.stackmap(i64 4, i32 0, i1 %cond, i32 %x, i32 %a, i32 %b, i32 %r)
 entry:
   br label %loop
 

--- a/llvm/test/CodeGen/X86/yk-stackmaps-spillreloads-fix-consts.ll
+++ b/llvm/test/CodeGen/X86/yk-stackmaps-spillreloads-fix-consts.ll
@@ -1,5 +1,5 @@
 ; RUN: llc -stop-after fix-stackmaps-spill-reloads --yk-insert-stackmaps --yk-stackmap-spillreloads-fix < %s  | FileCheck %s
-; CHECK: STACKMAP 2, 0, 0, $rbp, -8, 3, implicit-def dead early-clobber $r11
+; CHECK: STACKMAP 2, 0, 0, $rbp, -8, 3, 0, $rbp, -8, 3, implicit-def dead early-clobber $r11
 @hash_search_j = dso_local global i64 0, align 8
 
 ; Function Attrs: noinline nounwind optnone uwtable


### PR DESCRIPTION
ykllvm records stackmaps immediately after calls. Those stackmaps are effectively patchpoints (which we can't use as they only support 64-bit return values) which allow us to deopt _but_ our stackmaps don't tell us anything about a function's return value. For normal deopt that doesn't matter, but if we want to do "call" traces properly, we need that information.

This commit thus adds support for recording where a function's return value is placed. I have tried many, many designs for this, most of which run into LLVM internal weirdness, including what appears to be incorrect codegen. I briefly contemplated trying to work out why, but it quickly became clear that -- no matter how many modern tools I used! -- this was a tarpit with no way of estimating how long fix(es) might take.

This commit thus uses a horrible hack. For stackmaps immediately after a call we add an additional element to the stackmap recording the function's return value, if it has one, and if it is used later; otherwise we put a safe dummy value in its place. The good news is that this doesn't seem to hit any weird problems in LLVM and it has little or no impact on the speed of generated code (I couldn't measure any impact on yklua).